### PR TITLE
Testing get bases function with exceptions

### DIFF
--- a/sleap_roots/bases.py
+++ b/sleap_roots/bases.py
@@ -14,15 +14,10 @@ def get_bases(pts: np.ndarray) -> np.ndarray:
         If there is no root, or the roots don't have bases, an empty array of shape
         (0,2) is returned.
     """
-    # Check for edge cases where the root is missing or doesn't have bases.
-    if len(pts) == 0 or np.isnan(pts[:, 0].all()):
-        # Shape is (0, 2)
-        base_pts = np.empty((0, 2))
-
-    else:
-        # (instances, 2)
-        base_pts = pts[:, 0]
-        base_pts = base_pts[~np.isnan(base_pts[:, 0])]
+    # Get the first point of each instance. Shape is (instances, 2)
+    base_pts = pts[:, 0]
+    # Exclude NaN points
+    base_pts = base_pts[~np.isnan(base_pts[:, 0])]
     return base_pts
 
 
@@ -38,11 +33,13 @@ def get_root_lengths(pts: np.ndarray) -> np.ndarray:
         points are NaNs), an array of NaNs with shape (len(pts),) is returned.
         This is also the case for non-contiguous points at the moment.
     """
+    # Get the (x,y) differences of segments for each instance.
     segment_diffs = np.diff(pts, axis=1)
+    # Get the lengths of each segment by taking the norm.
     segment_lengths = np.linalg.norm(segment_diffs, axis=-1)
-
-    if np.isnan(segment_lengths).all():
-        total_lengths = np.empty((len(pts),)) ** np.nan
-    else:
-        total_lengths = np.nansum(segment_lengths, axis=-1)
+    # Add the segments together to get the total length using nansum.
+    total_lengths = np.nansum(segment_lengths, axis=-1)
+    # Find the NaN segment lengths and record NaN in place of 0 when finding the total
+    # length.
+    total_lengths[np.isnan(segment_lengths).all(axis=-1)] = np.nan
     return total_lengths

--- a/sleap_roots/bases.py
+++ b/sleap_roots/bases.py
@@ -15,8 +15,8 @@ def get_bases(pts: np.ndarray) -> np.ndarray:
     # Exceptions
     if len(pts) == 0 or np.isnan(pts[:, 0].all()):
         # (instances, 2)
-        base_pts = np.empty((len(pts),2))
-        
+        base_pts = np.empty((0, 2))
+
     else:
         # (instances, 2)
         base_pts = pts[:, 0]

--- a/sleap_roots/bases.py
+++ b/sleap_roots/bases.py
@@ -12,8 +12,15 @@ def get_bases(pts: np.ndarray) -> np.ndarray:
     Returns:
         Array of bases (instances, (x, y)).
     """
-    # (instances, 2)
-    base_pts = pts[:, 0]
+    # Exceptions
+    if len(pts) == 0 or np.isnan(pts[:, 0].all()):
+        # (instances, 2)
+        base_pts = np.empty((len(pts),2))
+        
+    else:
+        # (instances, 2)
+        base_pts = pts[:, 0]
+        base_pts = base_pts[~np.isnan(base_pts[:, 0])]
     return base_pts
 
 

--- a/sleap_roots/bases.py
+++ b/sleap_roots/bases.py
@@ -11,10 +11,11 @@ def get_bases(pts: np.ndarray) -> np.ndarray:
 
     Returns:
         Array of bases (instances, (x, y)).
+        If there is no root, or the roots don't have bases, an empty array of shape (0,2) is returned.
     """
-    # Exceptions
+    # Check for edge cases where the root is missing or doesn't have bases.
     if len(pts) == 0 or np.isnan(pts[:, 0].all()):
-        # (instances, 2)
+        # Shape is (0, 2)
         base_pts = np.empty((0, 2))
 
     else:

--- a/sleap_roots/bases.py
+++ b/sleap_roots/bases.py
@@ -11,8 +11,10 @@ def get_bases(pts: np.ndarray) -> np.ndarray:
 
     Returns:
         Array of bases (instances, (x, y)).
-        If there is no root, or the roots don't have bases, an empty array of shape (0,2) is returned.
+        If there is no root, or the roots don't have bases, an empty array of shape
+        (0,2) is returned.
     """
+
     # Check for edge cases where the root is missing or doesn't have bases.
     if len(pts) == 0 or np.isnan(pts[:, 0].all()):
         # Shape is (0, 2)
@@ -33,8 +35,16 @@ def get_root_lengths(pts: np.ndarray) -> np.ndarray:
 
     Returns:
         Array of root lengths of shape (instances,).
+        If there is no root, or the roots is one point only (all of the rest of the
+        points are NaNs), an array of NaNs with shape (len(pts),) is returned.
+        This is also the case for non-contiguous points at the moment.
     """
+
     segment_diffs = np.diff(pts, axis=1)
     segment_lengths = np.linalg.norm(segment_diffs, axis=-1)
-    total_lengths = np.nansum(segment_lengths, axis=-1)
+
+    if np.isnan(segment_lengths).all():
+        total_lengths = np.empty((len(pts),)) ** np.nan
+    else:
+        total_lengths = np.nansum(segment_lengths, axis=-1)
     return total_lengths

--- a/sleap_roots/bases.py
+++ b/sleap_roots/bases.py
@@ -14,7 +14,6 @@ def get_bases(pts: np.ndarray) -> np.ndarray:
         If there is no root, or the roots don't have bases, an empty array of shape
         (0,2) is returned.
     """
-
     # Check for edge cases where the root is missing or doesn't have bases.
     if len(pts) == 0 or np.isnan(pts[:, 0].all()):
         # Shape is (0, 2)
@@ -39,7 +38,6 @@ def get_root_lengths(pts: np.ndarray) -> np.ndarray:
         points are NaNs), an array of NaNs with shape (len(pts),) is returned.
         This is also the case for non-contiguous points at the moment.
     """
-
     segment_diffs = np.diff(pts, axis=1)
     segment_lengths = np.linalg.norm(segment_diffs, axis=-1)
 

--- a/tests/test_bases.py
+++ b/tests/test_bases.py
@@ -1,6 +1,76 @@
 from sleap_roots.bases import get_bases, get_root_lengths
 from sleap_roots import Series
 import numpy as np
+import pytest
+
+pts_standard = np.array(
+    [
+        [
+            [1, 2],
+            [3, 4],
+        ],
+        [
+            [5, 6],
+            [7, 8],
+        ],
+    ]
+)
+
+pts_no_bases = np.array(
+    [
+        [
+            [np.nan, np.nan],
+            [3, 4],
+        ],
+        [
+            [np.nan, np.nan],
+            [7, 8],
+        ],
+    ]
+)
+
+
+pts_one_base = np.array(
+    [
+        [
+            [1, 2],
+            [3, 4],
+        ],
+        [
+            [np.nan, np.nan],
+            [7, 8],
+        ],
+    ]
+)
+
+
+pts_no_roots = np.array(
+    [
+        [
+            [np.nan, np.nan],
+            [np.nan, np.nan],
+        ],
+        [
+            [np.nan, np.nan],
+            [np.nan, np.nan],
+        ],
+    ]
+)
+
+
+@pytest.mark.parametrize(
+    "test_input,expected_shape,expected_array",
+    [
+        (pts_standard, (2, 2), [[1, 2], [5, 6]]),
+        (pts_no_bases, (0, 2), np.empty((0, 2))),
+        (pts_one_base, (1, 2), [[1, 2]]),
+        (pts_no_roots, (0, 2), np.empty((0, 2))),
+    ],
+)
+def test_bases(test_input, expected):
+    bases = get_bases(test_input)
+    assert bases.shape == expected_shape
+    np.testing.assert_array_equal(bases, expected_array)
 
 
 def test_get_bases_standard():

--- a/tests/test_bases.py
+++ b/tests/test_bases.py
@@ -132,27 +132,8 @@ def test_get_root_lengths(canola_h5):
     )
 
 
-def test_get_root_lengths_one_point(pts_no_bases):
+def test_get_root_lengths_no_roots(pts_no_bases):
     root_lengths = get_root_lengths(pts_no_bases)
-    assert root_lengths.shape == (2,)
-    np.testing.assert_array_almost_equal(root_lengths, np.array([np.nan, np.nan]))
-
-
-def test_get_root_lengths_no_roots():
-    pts = np.array(
-        [
-            [
-                [np.nan, np.nan],
-                [np.nan, np.nan],
-            ],
-            [
-                [np.nan, np.nan],
-                [np.nan, np.nan],
-            ],
-        ]
-    )
-
-    root_lengths = get_root_lengths(pts)
     assert root_lengths.shape == (2,)
     np.testing.assert_array_almost_equal(root_lengths, np.array([np.nan, np.nan]))
 

--- a/tests/test_bases.py
+++ b/tests/test_bases.py
@@ -3,78 +3,10 @@ from sleap_roots import Series
 import numpy as np
 import pytest
 
-pts_standard = np.array(
-    [
-        [
-            [1, 2],
-            [3, 4],
-        ],
-        [
-            [5, 6],
-            [7, 8],
-        ],
-    ]
-)
 
-pts_no_bases = np.array(
-    [
-        [
-            [np.nan, np.nan],
-            [3, 4],
-        ],
-        [
-            [np.nan, np.nan],
-            [7, 8],
-        ],
-    ]
-)
-
-
-pts_one_base = np.array(
-    [
-        [
-            [1, 2],
-            [3, 4],
-        ],
-        [
-            [np.nan, np.nan],
-            [7, 8],
-        ],
-    ]
-)
-
-
-pts_no_roots = np.array(
-    [
-        [
-            [np.nan, np.nan],
-            [np.nan, np.nan],
-        ],
-        [
-            [np.nan, np.nan],
-            [np.nan, np.nan],
-        ],
-    ]
-)
-
-
-@pytest.mark.parametrize(
-    "test_input,expected_shape,expected_array",
-    [
-        (pts_standard, (2, 2), [[1, 2], [5, 6]]),
-        (pts_no_bases, (0, 2), np.empty((0, 2))),
-        (pts_one_base, (1, 2), [[1, 2]]),
-        (pts_no_roots, (0, 2), np.empty((0, 2))),
-    ],
-)
-def test_bases(test_input, expected):
-    bases = get_bases(test_input)
-    assert bases.shape == expected_shape
-    np.testing.assert_array_equal(bases, expected_array)
-
-
-def test_get_bases_standard():
-    pts = np.array(
+@pytest.fixture
+def pts_standard():
+    return np.array(
         [
             [
                 [1, 2],
@@ -87,13 +19,10 @@ def test_get_bases_standard():
         ]
     )
 
-    bases = get_bases(pts)
-    assert bases.shape == (2, 2)
-    np.testing.assert_array_equal(bases, [[1, 2], [5, 6]])
 
-
-def test_get_bases_no_bases():
-    pts = np.array(
+@pytest.fixture
+def pts_no_bases():
+    return np.array(
         [
             [
                 [np.nan, np.nan],
@@ -106,13 +35,10 @@ def test_get_bases_no_bases():
         ]
     )
 
-    bases = get_bases(pts)
-    assert bases.shape == (0, 2)
-    np.testing.assert_array_equal(bases, np.empty((0, 2)))
 
-
-def test_get_bases_one_base():
-    pts = np.array(
+@pytest.fixture
+def pts_one_base():
+    return np.array(
         [
             [
                 [1, 2],
@@ -125,13 +51,10 @@ def test_get_bases_one_base():
         ]
     )
 
-    bases = get_bases(pts)
-    assert bases.shape == (1, 2)
-    np.testing.assert_array_equal(bases, [[1, 2]])
 
-
-def test_get_bases_no_roots():
-    pts = np.array(
+@pytest.fixture
+def pts_no_roots():
+    return np.array(
         [
             [
                 [np.nan, np.nan],
@@ -144,7 +67,45 @@ def test_get_bases_no_roots():
         ]
     )
 
-    bases = get_bases(pts)
+
+@pytest.fixture
+def pts_not_contiguous():
+    return np.array(
+        [
+            [
+                [1, 2],
+                [np.nan, np.nan],
+                [3, 4],
+            ],
+            [
+                [5, 6],
+                [np.nan, np.nan],
+                [7, 8],
+            ],
+        ]
+    )
+
+
+def test_bases_standard(pts_standard):
+    bases = get_bases(pts_standard)
+    assert bases.shape == (2, 2)
+    np.testing.assert_array_equal(bases, [[1, 2], [5, 6]])
+
+
+def test_bases_no_bases(pts_no_bases):
+    bases = get_bases(pts_no_bases)
+    assert bases.shape == (0, 2)
+    np.testing.assert_array_equal(bases, np.empty((0, 2)))
+
+
+def test_bases_one_base(pts_one_base):
+    bases = get_bases(pts_one_base)
+    assert bases.shape == (1, 2)
+    np.testing.assert_array_equal(bases, [[1, 2]])
+
+
+def test_bases_no_roots(pts_no_roots):
+    bases = get_bases(pts_no_roots)
     assert bases.shape == (0, 2)
     np.testing.assert_array_equal(bases, np.empty((0, 2)))
 
@@ -171,6 +132,12 @@ def test_get_root_lengths(canola_h5):
     )
 
 
+def test_get_root_lengths_one_point(pts_no_bases):
+    root_lengths = get_root_lengths(pts_no_bases)
+    assert root_lengths.shape == (2,)
+    np.testing.assert_array_almost_equal(root_lengths, np.array([np.nan, np.nan]))
+
+
 def test_get_root_lengths_no_roots():
     pts = np.array(
         [
@@ -185,8 +152,6 @@ def test_get_root_lengths_no_roots():
         ]
     )
 
-    assert pts.shape == (2, 2, 2)
-
     root_lengths = get_root_lengths(pts)
     assert root_lengths.shape == (2,)
-    np.testing.assert_array_almost_equal(root_lengths, [0, 0])
+    np.testing.assert_array_almost_equal(root_lengths, np.array([np.nan, np.nan]))

--- a/tests/test_bases.py
+++ b/tests/test_bases.py
@@ -155,3 +155,11 @@ def test_get_root_lengths_no_roots():
     root_lengths = get_root_lengths(pts)
     assert root_lengths.shape == (2,)
     np.testing.assert_array_almost_equal(root_lengths, np.array([np.nan, np.nan]))
+
+
+def test_get_root_lengths_one_point(pts_one_base):
+    root_lengths = get_root_lengths(pts_one_base)
+    assert root_lengths.shape == (2,)
+    np.testing.assert_array_almost_equal(
+        root_lengths, np.array([2.82842712475, np.nan])
+    )

--- a/tests/test_bases.py
+++ b/tests/test_bases.py
@@ -3,7 +3,7 @@ from sleap_roots import Series
 import numpy as np
 
 
-def test_get_bases():
+def test_get_bases_standard():
     pts = np.array(
         [
             [
@@ -20,6 +20,63 @@ def test_get_bases():
     bases = get_bases(pts)
     assert bases.shape == (2, 2)
     np.testing.assert_array_equal(bases, [[1, 2], [5, 6]])
+
+
+def test_get_bases_no_bases():
+    pts = np.array(
+        [
+            [
+                [np.nan, np.nan],
+                [3, 4],
+            ],
+            [
+                [np.nan, np.nan],
+                [7, 8],
+            ],
+        ]
+    )
+
+    bases = get_bases(pts)
+    assert bases.shape == (0, 2)
+    np.testing.assert_array_equal(bases, np.empty((0, 2)))
+
+
+def test_get_bases_one_base():
+    pts = np.array(
+        [
+            [
+                [1, 2],
+                [3, 4],
+            ],
+            [
+                [np.nan, np.nan],
+                [7, 8],
+            ],
+        ]
+    )
+
+    bases = get_bases(pts)
+    assert bases.shape == (1, 2)
+    np.testing.assert_array_equal(bases, [[1, 2]])
+
+
+def test_get_bases_no_roots():
+    pts = np.array(
+        [
+            [
+                [np.nan, np.nan],
+                [np.nan, np.nan],
+            ],
+            [
+                [np.nan, np.nan],
+                [np.nan, np.nan],
+            ],
+        ]
+    )
+
+    bases = get_bases(pts)
+    assert bases.shape == (0, 2)
+    np.testing.assert_array_equal(bases, np.empty((0, 2)))
 
 
 def test_get_root_lengths(canola_h5):
@@ -42,3 +99,24 @@ def test_get_root_lengths(canola_h5):
     np.testing.assert_array_almost_equal(
         root_lengths, [20.129579, 62.782368, 80.268003, 34.925591, 3.89724]
     )
+
+
+def test_get_root_lengths_no_roots():
+    pts = np.array(
+        [
+            [
+                [np.nan, np.nan],
+                [np.nan, np.nan],
+            ],
+            [
+                [np.nan, np.nan],
+                [np.nan, np.nan],
+            ],
+        ]
+    )
+
+    assert pts.shape == (2, 2, 2)
+
+    root_lengths = get_root_lengths(pts)
+    assert root_lengths.shape == (2,)
+    np.testing.assert_array_almost_equal(root_lengths, [0, 0])


### PR DESCRIPTION
- Tested `get_bases` and `get_root_lengths` with canola data, an empty numpy array, and roots without bases. 
- Added `test_get_bases_standard`, `test_get_bases_no_bases`, `test_get_bases_one_base`, `test_get_bases_no_roots`, `test_get_root_lengths_no_roots` to `test_bases.py`. 