### PR TITLE
Add root angle (based on base) module.

### DIFF
--- a/sleap_roots/__init__.py
+++ b/sleap_roots/__init__.py
@@ -1,5 +1,6 @@
 """High-level imports."""
 
+import sleap_roots.angle
 import sleap_roots.bases
 import sleap_roots.convhull
 import sleap_roots.ellipse

--- a/sleap_roots/angle.py
+++ b/sleap_roots/angle.py
@@ -1,0 +1,28 @@
+"""Get angle of each root."""
+
+import numpy as np
+
+
+def get_root_base_angle(pts: np.ndarray, base_ind=0, tip_ind=1) -> np.ndarray:
+    """Find angles for each root.
+
+    Args:
+        pts: Numpy array of points of shape (instances, nodes, 2).
+        base_ind: Index of base node in the skeleton (default: 0).
+        tip_ind: Index of distal node in the skeleton (default: 1).
+            Use 1 to get the angle to the second node.
+
+    Returns:
+        An array of shape (instances,) of angles in degrees, modulo 360.
+    """
+    while np.isnan(pts[:, tip_ind]).all() and tip_ind < int(pts.shape[1] / 2 - 1):
+        tip_ind += 1
+
+    if tip_ind < int(pts.shape[1] / 2):
+        xy = pts[:, tip_ind] - pts[:, base_ind]  # center on base node
+        # calculate the angle and convert to the start with gravity ([0,-1] direction)
+        ang = np.arctan2(-xy[..., 1], xy[..., 0]) * 180 / np.pi
+        angs = abs(ang + 90) if ang.all() < 90 else abs(-(360 - 90 - ang))
+    else:
+        angs = np.nan
+    return angs

--- a/sleap_roots/angle.py
+++ b/sleap_roots/angle.py
@@ -19,6 +19,8 @@ def get_node_ind(pts: np.ndarray, proximal=True) -> np.ndarray:
         ind = 1 if proximal else pts.shape[1] - 1  # set initial proximal/distal node
         while np.isnan(pts[i, ind]).any():
             ind += 1 if proximal else -1
+            if (ind == pts.shape[1] and proximal) or (ind == 0 and not proximal):
+                break
         node_ind.append(ind)
     return node_ind
 

--- a/sleap_roots/angle.py
+++ b/sleap_roots/angle.py
@@ -1,28 +1,52 @@
 """Get angle of each root."""
 
 import numpy as np
+import math
 
 
-def get_root_base_angle(pts: np.ndarray, base_ind=0, tip_ind=1) -> np.ndarray:
+def get_node_ind(pts: np.ndarray, proximal=True) -> np.ndarray:
+    """Find nproximal/distal node index.
+
+    Args:
+        pts: Numpy array of points of shape (instances, nodes, 2).
+        proximal: Boolean value, where true is proximal (default), false is distal.
+
+    Returns:
+        An array of shape (instances,) of proximal or distal node index.
+    """
+    node_ind = []
+    for i in range(pts.shape[0]):
+        ind = 1 if proximal else pts.shape[1] - 1  # set initial proximal/distal node
+        while np.isnan(pts[i, ind]).any():
+            ind += 1 if proximal else -1
+        node_ind.append(ind)
+    return node_ind
+
+
+def get_root_angle(pts: np.ndarray, proximal=True, base_ind=0) -> np.ndarray:
     """Find angles for each root.
 
     Args:
         pts: Numpy array of points of shape (instances, nodes, 2).
+        proximal: Boolean value, where true is proximal (default), false is distal.
         base_ind: Index of base node in the skeleton (default: 0).
-        tip_ind: Index of distal node in the skeleton (default: 1).
-            Use 1 to get the angle to the second node.
 
     Returns:
         An array of shape (instances,) of angles in degrees, modulo 360.
     """
-    while np.isnan(pts[:, tip_ind]).all() and tip_ind < int(pts.shape[1] / 2 - 1):
-        tip_ind += 1
-
-    if tip_ind < int(pts.shape[1] / 2):
-        xy = pts[:, tip_ind] - pts[:, base_ind]  # center on base node
-        # calculate the angle and convert to the start with gravity ([0,-1] direction)
-        ang = np.arctan2(-xy[..., 1], xy[..., 0]) * 180 / np.pi
-        angs = abs(ang + 90) if ang.all() < 90 else abs(-(360 - 90 - ang))
-    else:
-        angs = np.nan
-    return angs
+    node_ind = get_node_ind(pts, proximal)  # get proximal or distal node index
+    angs_root = []
+    for i in range(len(node_ind)):
+        # filter out the cases if all nan nodes in last/first half part
+        # to calculate proximal/distal angle
+        if (node_ind[i] < math.ceil(pts.shape[1] / 2) and proximal) or (
+            node_ind[i] >= math.floor(pts.shape[1] / 2) and not (proximal)
+        ):
+            xy = pts[i, node_ind[i], :] - pts[i, base_ind, :]  # center on base node
+            # calculate the angle and convert to the start with gravity direction
+            ang = np.arctan2(-xy[1], xy[0]) * 180 / np.pi
+            angs = abs(ang + 90) if ang < 90 else abs(-(360 - 90 - ang))
+        else:
+            angs = np.nan
+        angs_root.append(angs)
+    return np.array(angs_root)

--- a/tests/test_angle.py
+++ b/tests/test_angle.py
@@ -53,6 +53,22 @@ def pts_nan6():
 
 
 @pytest.fixture
+def pts_nanall():
+    return np.array(
+        [
+            [
+                [np.nan, np.nan],
+                [np.nan, np.nan],
+                [np.nan, np.nan],
+                [np.nan, np.nan],
+                [np.nan, np.nan],
+                [np.nan, np.nan],
+            ]
+        ]
+    )
+
+
+@pytest.fixture
 def pts_nan32():
     return np.array(
         [
@@ -138,6 +154,13 @@ def test_get_node_ind_nan6(pts_nan6):
     np.testing.assert_array_equal(node_ind, [4])
 
 
+# test get_node_ind function using root with all nan node
+def test_get_node_ind_nanall(pts_nanall):
+    proximal = False
+    node_ind = get_node_ind(pts_nanall, proximal)
+    np.testing.assert_array_equal(node_ind, [0])
+
+
 # test canola get_root_angle function (base node to distal node angle)
 def test_get_root_angle_distal(canola_h5):
     series = Series.load(
@@ -180,3 +203,11 @@ def test_get_root_angle_proximal_5node(pts_nan32_5node):
     angs = get_root_angle(pts_nan32_5node, proximal)
     assert angs.shape == (2,)
     np.testing.assert_almost_equal(angs, [np.nan, 2.3339111], decimal=3)
+
+
+# test get_root_angle function using root/instance with all nan value
+def test_get_root_angle_proximal_5node(pts_nanall):
+    proximal = True
+    angs = get_root_angle(pts_nanall, proximal)
+    assert angs.shape == (1,)
+    np.testing.assert_almost_equal(angs, np.nan, decimal=3)

--- a/tests/test_angle.py
+++ b/tests/test_angle.py
@@ -1,78 +1,182 @@
-from sleap_roots import Series
 import numpy as np
-from sleap_roots.angle import get_root_base_angle
+import pytest
+from sleap_roots import Series
+from sleap_roots.angle import get_node_ind, get_root_angle
 
 
-def test_get_root_base_angle(canola_h5):
+@pytest.fixture
+def pts_nan2():
+    return np.array(
+        [
+            [
+                [852.17755127, 216.95648193],
+                [np.nan, 472.83520508],
+                [844.45300293, 472.83520508],
+                [837.03405762, 588.5123291],
+                [828.87963867, 692.72009277],
+                [816.71142578, 808.12585449],
+            ]
+        ]
+    )
+
+
+@pytest.fixture
+def pts_nan3():
+    return np.array(
+        [
+            [
+                [852.17755127, 216.95648193],
+                [np.nan, np.nan],
+                [np.nan, np.nan],
+                [837.03405762, 588.5123291],
+                [828.87963867, 692.72009277],
+                [816.71142578, 808.12585449],
+            ]
+        ]
+    )
+
+
+@pytest.fixture
+def pts_nan6():
+    return np.array(
+        [
+            [
+                [852.17755127, 216.95648193],
+                [np.nan, np.nan],
+                [np.nan, np.nan],
+                [837.03405762, 588.5123291],
+                [828.87963867, 692.72009277],
+                [np.nan, np.nan],
+            ]
+        ]
+    )
+
+
+@pytest.fixture
+def pts_nan32():
+    return np.array(
+        [
+            [
+                [852.17755127, 216.95648193],
+                [np.nan, np.nan],
+                [np.nan, np.nan],
+                [837.03405762, 588.5123291],
+                [828.87963867, 692.72009277],
+                [816.71142578, 808.12585449],
+            ],
+            [
+                [852.17755127, 216.95648193],
+                [np.nan, np.nan],
+                [844.45300293, 472.83520508],
+                [837.03405762, 588.5123291],
+                [828.87963867, 692.72009277],
+                [816.71142578, 808.12585449],
+            ],
+        ]
+    )
+
+
+@pytest.fixture
+def pts_nan32_5node():
+    return np.array(
+        [
+            [
+                [852.17755127, 216.95648193],
+                [np.nan, np.nan],
+                [np.nan, np.nan],
+                [828.87963867, 692.72009277],
+                [816.71142578, 808.12585449],
+            ],
+            [
+                [852.17755127, 216.95648193],
+                [np.nan, np.nan],
+                [837.03405762, 588.5123291],
+                [828.87963867, 692.72009277],
+                [816.71142578, 808.12585449],
+            ],
+        ]
+    )
+
+
+# test get_node_ind function
+def test_get_node_ind(canola_h5):
     series = Series.load(
         canola_h5, primary_name="primary_multi_day", lateral_name="lateral_3_nodes"
     )
     primary, lateral = series[0]
-
     pts = primary.numpy()
-    angs = get_root_base_angle(pts)
+    proximal = True
+    node_ind = get_node_ind(pts, proximal)
+    np.testing.assert_array_equal(node_ind, [1])
+
+
+# test get_node_ind function using root that without second node
+def test_get_node_ind_nan2(pts_nan2):
+    proximal = True
+    node_ind = get_node_ind(pts_nan2, proximal)
+    np.testing.assert_array_equal(node_ind, [2])
+
+
+# test get_node_ind function using root that without second and third nodes
+def test_get_node_ind_nan3(pts_nan3):
+    proximal = True
+    node_ind = get_node_ind(pts_nan3, proximal)
+    np.testing.assert_array_equal(node_ind, [3])
+
+
+# test get_node_ind function using two roots/instances
+def test_get_node_ind_nan32(pts_nan32):
+    proximal = True
+    node_ind = get_node_ind(pts_nan32, proximal)
+    np.testing.assert_array_equal(node_ind, [3, 2])
+
+
+# test get_node_ind function using root that without last node
+def test_get_node_ind_nan6(pts_nan6):
+    proximal = False
+    node_ind = get_node_ind(pts_nan6, proximal)
+    np.testing.assert_array_equal(node_ind, [4])
+
+
+# test canola get_root_angle function (base node to distal node angle)
+def test_get_root_angle_distal(canola_h5):
+    series = Series.load(
+        canola_h5, primary_name="primary_multi_day", lateral_name="lateral_3_nodes"
+    )
+    primary, lateral = series[0]
+    pts = primary.numpy()
+    proximal = False
+    angs = get_root_angle(pts, proximal)
     assert angs.shape == (1,)
     assert pts.shape == (1, 6, 2)
-    np.testing.assert_almost_equal(angs, 50.1312956, decimal=3)
+    np.testing.assert_almost_equal(angs, 7.7511306, decimal=3)
 
-    # test the instance with second node is nan value
-    pts = np.array(
-        [
-            [
-                [852.17755127, 216.95648193],
-                [np.nan, np.nan],
-                [844.45300293, 472.83520508],
-                [837.03405762, 588.5123291],
-                [828.87963867, 692.72009277],
-                [816.71142578, 808.12585449],
-            ]
-        ]
-    )
-    angs = get_root_base_angle(pts)
-    assert angs.shape == (1,)
-    assert pts.shape == (1, 6, 2)
-    np.testing.assert_almost_equal(angs, 1.7291381, decimal=3)
 
-    # test the instance with third node is nan value
-    pts = np.array(
-        [
-            [
-                [852.17755127, 216.95648193],
-                [np.nan, np.nan],
-                [np.nan, np.nan],
-                [837.03405762, 588.5123291],
-                [828.87963867, 692.72009277],
-                [816.71142578, 808.12585449],
-            ]
-        ]
+# test rice get_root_angle function (base node to proximal node angle)
+def test_get_root_angle_priximal_rice(rice_h5):
+    series = Series.load(
+        rice_h5, primary_name="main_3do_6nodes", lateral_name="longest_3do_6nodes"
     )
-    angs = get_root_base_angle(pts)
-    assert angs.shape == (1,)
-    assert pts.shape == (1, 6, 2)
-    np.testing.assert_almost_equal(angs, np.nan, decimal=3)
-
-    # test two instances
-    pts = np.array(
-        [
-            [
-                [852.17755127, 216.95648193],
-                [np.nan, np.nan],
-                [np.nan, np.nan],
-                [837.03405762, 588.5123291],
-                [828.87963867, 692.72009277],
-                [816.71142578, 808.12585449],
-            ],
-            [
-                [852.17755127, 216.95648193],
-                [np.nan, np.nan],
-                [844.45300293, 472.83520508],
-                [837.03405762, 588.5123291],
-                [828.87963867, 692.72009277],
-                [816.71142578, 808.12585449],
-            ],
-        ]
-    )
-    angs = get_root_base_angle(pts)
+    primary, lateral = series[0]
+    pts = primary.numpy()
+    proximal = True
+    angs = get_root_angle(pts, proximal)
     assert angs.shape == (2,)
     assert pts.shape == (2, 6, 2)
+    np.testing.assert_almost_equal(angs, [17.3180819, 3.2692877], decimal=3)
+
+
+# test get_root_angle function using two roots/instances (base node to proximal node angle)
+def test_get_root_angle_proximal(pts_nan32):
+    proximal = True
+    angs = get_root_angle(pts_nan32, proximal)
+    assert angs.shape == (2,)
     np.testing.assert_almost_equal(angs, [np.nan, 1.7291381], decimal=3)
+
+
+# test get_root_angle function using two roots/instances (base node to proximal node angle)
+def test_get_root_angle_proximal_5node(pts_nan32_5node):
+    proximal = True
+    angs = get_root_angle(pts_nan32_5node, proximal)
+    assert angs.shape == (2,)
+    np.testing.assert_almost_equal(angs, [np.nan, 2.3339111], decimal=3)

--- a/tests/test_angle.py
+++ b/tests/test_angle.py
@@ -1,0 +1,78 @@
+from sleap_roots import Series
+import numpy as np
+from sleap_roots.angle import get_root_base_angle
+
+
+def test_get_root_base_angle(canola_h5):
+    series = Series.load(
+        canola_h5, primary_name="primary_multi_day", lateral_name="lateral_3_nodes"
+    )
+    primary, lateral = series[0]
+
+    pts = primary.numpy()
+    angs = get_root_base_angle(pts)
+    assert angs.shape == (1,)
+    assert pts.shape == (1, 6, 2)
+    np.testing.assert_almost_equal(angs, 50.1312956, decimal=3)
+
+    # test the instance with second node is nan value
+    pts = np.array(
+        [
+            [
+                [852.17755127, 216.95648193],
+                [np.nan, np.nan],
+                [844.45300293, 472.83520508],
+                [837.03405762, 588.5123291],
+                [828.87963867, 692.72009277],
+                [816.71142578, 808.12585449],
+            ]
+        ]
+    )
+    angs = get_root_base_angle(pts)
+    assert angs.shape == (1,)
+    assert pts.shape == (1, 6, 2)
+    np.testing.assert_almost_equal(angs, 1.7291381, decimal=3)
+
+    # test the instance with third node is nan value
+    pts = np.array(
+        [
+            [
+                [852.17755127, 216.95648193],
+                [np.nan, np.nan],
+                [np.nan, np.nan],
+                [837.03405762, 588.5123291],
+                [828.87963867, 692.72009277],
+                [816.71142578, 808.12585449],
+            ]
+        ]
+    )
+    angs = get_root_base_angle(pts)
+    assert angs.shape == (1,)
+    assert pts.shape == (1, 6, 2)
+    np.testing.assert_almost_equal(angs, np.nan, decimal=3)
+
+    # test two instances
+    pts = np.array(
+        [
+            [
+                [852.17755127, 216.95648193],
+                [np.nan, np.nan],
+                [np.nan, np.nan],
+                [837.03405762, 588.5123291],
+                [828.87963867, 692.72009277],
+                [816.71142578, 808.12585449],
+            ],
+            [
+                [852.17755127, 216.95648193],
+                [np.nan, np.nan],
+                [844.45300293, 472.83520508],
+                [837.03405762, 588.5123291],
+                [828.87963867, 692.72009277],
+                [816.71142578, 808.12585449],
+            ],
+        ]
+    )
+    angs = get_root_base_angle(pts)
+    assert angs.shape == (2,)
+    assert pts.shape == (2, 6, 2)
+    np.testing.assert_almost_equal(angs, [np.nan, 1.7291381], decimal=3)


### PR DESCRIPTION
- Add `get_root_angle` and `get_node_ind` function in `angle` module.
- Add test cases in `test_angle` module using canola and rice cases, nan value of the second and third nodes, plant with 2 instances, and instance with odd number (i.e., 5) of nodes.
