### PR TITLE
Add convex hull function

### DIFF
--- a/sleap_roots/convhull.py
+++ b/sleap_roots/convhull.py
@@ -1,1 +1,56 @@
 """Convex hull fitting and derived trait calculation."""
+
+import numpy as np
+from scipy.spatial import ConvexHull, convex_hull_plot_2d
+from scipy.spatial.distance import pdist
+from typing import Tuple
+
+
+def get_convhull(
+    pts: np.ndarray,
+) -> Tuple[float, float, float, float, float, float, float]:
+    """Get the convex hull for the points per frame.
+
+    Args:
+        pts: Root landmarks as array of shape (..., 2).
+
+    Returns:
+        A tuple of (perimeters, areas, longest_dists, shortest_dists, median_dists,
+        max_widths, max_heights) containing perimeter, area, longest distance between
+        vertices, smallest distance between vertices, median distance between vertices,
+        maximum width and maximum height of the convex hull.
+
+        If the convex hull fitting fails, NaNs are returned.
+    """
+    pts = pts.reshape(-1, 2)
+    pts = pts[~(np.isnan(pts).any(axis=-1))]
+
+    if len(pts) <= 2:
+        return np.full((7,), np.nan)
+
+    # Get Convex Hull
+    hull = ConvexHull(pts)
+    # perimeter
+    perimeter = hull.area
+    # area
+    area = hull.volume
+    # longest distance between vertices
+    longest_dist = np.nanmax(pdist(hull.points[hull.vertices], "euclidean"))
+    # smallest distance between vertices
+    shortest_dist = np.nanmin(pdist(hull.points[hull.vertices], "euclidean"))
+    # median distance between vertices
+    median_dist = np.nanmedian(pdist(hull.points[hull.vertices], "euclidean"))
+    # max 'width'
+    max_width = np.nanmax(pts[:, 0]) - np.nanmin(pts[:, 0])
+    # max 'height'
+    max_height = np.nanmax(pts[:, 1]) - np.nanmin(pts[:, 1])
+
+    return (
+        perimeter,
+        area,
+        longest_dist,
+        shortest_dist,
+        median_dist,
+        max_width,
+        max_height,
+    )

--- a/sleap_roots/convhull.py
+++ b/sleap_roots/convhull.py
@@ -65,11 +65,11 @@ def get_convhull_features(
 
     pts = pts.reshape(-1, 2)
     pts = pts[~(np.isnan(pts).any(axis=-1))]
-    
+
     # max 'width'
-    max_width = np.nanmax(pts[:, 0]) - np.nanmin(pts[:,  0])
+    max_width = np.nanmax(pts[:, 0]) - np.nanmin(pts[:, 0])
     # max 'height'
-    max_height = np.nanmax(pts[:,  1]) - np.nanmin(pts[:, 1])
+    max_height = np.nanmax(pts[:, 1]) - np.nanmin(pts[:, 1])
 
     return (
         perimeter,

--- a/sleap_roots/convhull.py
+++ b/sleap_roots/convhull.py
@@ -3,33 +3,55 @@
 import numpy as np
 from scipy.spatial import ConvexHull, convex_hull_plot_2d
 from scipy.spatial.distance import pdist
-from typing import Tuple
+from typing import Tuple, Optional, Union
 
 
-def get_convhull(
-    pts: np.ndarray,
-) -> Tuple[float, float, float, float, float, float, float]:
+def get_convhull(pts: np.ndarray) -> Optional[ConvexHull]:
     """Get the convex hull for the points per frame.
 
     Args:
         pts: Root landmarks as array of shape (..., 2).
 
     Returns:
-        A tuple of (perimeters, areas, longest_dists, shortest_dists, median_dists,
-        max_widths, max_heights) containing perimeter, area, longest distance between
-        vertices, smallest distance between vertices, median distance between vertices,
-        maximum width and maximum height of the convex hull.
-
-        If the convex hull fitting fails, NaNs are returned.
+        An object of convex hull.
     """
     pts = pts.reshape(-1, 2)
     pts = pts[~(np.isnan(pts).any(axis=-1))]
 
     if len(pts) <= 2:
+        return None
+
+    # Get convex hull
+    hull = ConvexHull(pts)
+
+    return hull
+
+
+def get_convhull_features(
+    pts: Union[np.ndarray, ConvexHull]
+) -> Tuple[float, float, float, float, float, float, float]:
+    """Get the convex hull features for the points per frame.
+
+    Args:
+        pts: Root landmarks as array of shape (..., 2).
+
+    Returns:
+        A tuple of 7 convex hull features
+            perimeters, perimeter of the convex hull
+            areas, area of the convex hull
+            longest_dists, longest distance between vertices
+            shortest_dists, smallest distance between vertices
+            median_dists, median distance between vertices
+            max_widths, maximum width of convex hull
+            max_heights, maximum height of convex hull
+
+        If the convex hull fitting fails, NaNs are returned.
+    """
+    hull = pts if type(pts) == ConvexHull else get_convhull(pts)
+
+    if hull is None:
         return np.full((7,), np.nan)
 
-    # Get Convex Hull
-    hull = ConvexHull(pts)
     # perimeter
     perimeter = hull.area
     # area
@@ -40,10 +62,14 @@ def get_convhull(
     shortest_dist = np.nanmin(pdist(hull.points[hull.vertices], "euclidean"))
     # median distance between vertices
     median_dist = np.nanmedian(pdist(hull.points[hull.vertices], "euclidean"))
+
+    pts = pts.reshape(-1, 2)
+    pts = pts[~(np.isnan(pts).any(axis=-1))]
+    
     # max 'width'
-    max_width = np.nanmax(pts[:, 0]) - np.nanmin(pts[:, 0])
+    max_width = np.nanmax(pts[:, 0]) - np.nanmin(pts[:,  0])
     # max 'height'
-    max_height = np.nanmax(pts[:, 1]) - np.nanmin(pts[:, 1])
+    max_height = np.nanmax(pts[:,  1]) - np.nanmin(pts[:, 1])
 
     return (
         perimeter,

--- a/tests/test_convhull.py
+++ b/tests/test_convhull.py
@@ -42,7 +42,7 @@ def pts_nan_5node():
 
 
 # test canola model
-def test_get_ellipse_canola(canola_h5):
+def test_get_convhull_canola(canola_h5):
     series = Series.load(
         canola_h5, primary_name="primary_multi_day", lateral_name="lateral_3_nodes"
     )
@@ -72,7 +72,7 @@ def test_get_ellipse_canola(canola_h5):
 
 
 # test rice model
-def test_get_ellipse_rice(rice_h5):
+def test_get_convhull_rice(rice_h5):
     series = Series.load(
         rice_h5, primary_name="main_3do_6nodes", lateral_name="longest_3do_6nodes"
     )
@@ -102,7 +102,7 @@ def test_get_ellipse_rice(rice_h5):
 
 
 # test plant with 2 roots/instances with nan nodes
-def test_get_ellipse_nan(pts_nan31_5node):
+def test_get_convhull_nan(pts_nan31_5node):
     (
         perimeters,
         areas,
@@ -123,7 +123,7 @@ def test_get_ellipse_nan(pts_nan31_5node):
 
 
 # test plant with 1 root/instance with only 2 non-nan nodes
-def test_get_ellipse_nanall(pts_nan_5node):
+def test_get_convhull_nanall(pts_nan_5node):
     (
         perimeters,
         areas,

--- a/tests/test_convhull.py
+++ b/tests/test_convhull.py
@@ -1,5 +1,6 @@
+from scipy.spatial import ConvexHull
 from sleap_roots import Series
-from sleap_roots.convhull import get_convhull
+from sleap_roots.convhull import get_convhull, get_convhull_features
 import numpy as np
 import pytest
 
@@ -41,8 +42,22 @@ def pts_nan_5node():
     )
 
 
-# test canola model
+# test get_convhull function using canola
 def test_get_convhull_canola(canola_h5):
+    series = Series.load(
+        canola_h5, primary_name="primary_multi_day", lateral_name="lateral_3_nodes"
+    )
+    primary, lateral = series[0]
+
+    primary_points = primary.numpy().reshape(-1, 2)
+    lateral_points = lateral.numpy().reshape(-1, 2)
+    convex_hull_points = np.concatenate((primary_points, lateral_points), axis=0)
+    convex_hull = get_convhull(convex_hull_points)
+    assert type(convex_hull) == ConvexHull
+
+
+# test canola model
+def test_get_convhull_features_canola(canola_h5):
     series = Series.load(
         canola_h5, primary_name="primary_multi_day", lateral_name="lateral_3_nodes"
     )
@@ -60,7 +75,7 @@ def test_get_convhull_canola(canola_h5):
         median_dists,
         max_widths,
         max_heights,
-    ) = get_convhull(convex_hull_points)
+    ) = get_convhull_features(convex_hull_points)
 
     np.testing.assert_almost_equal(perimeters, 1910.0476127930017, decimal=3)
     np.testing.assert_almost_equal(areas, 93255.32153574759, decimal=3)
@@ -72,7 +87,7 @@ def test_get_convhull_canola(canola_h5):
 
 
 # test rice model
-def test_get_convhull_rice(rice_h5):
+def test_get_convhull_features_rice(rice_h5):
     series = Series.load(
         rice_h5, primary_name="main_3do_6nodes", lateral_name="longest_3do_6nodes"
     )
@@ -90,7 +105,7 @@ def test_get_convhull_rice(rice_h5):
         median_dists,
         max_widths,
         max_heights,
-    ) = get_convhull(convex_hull_points)
+    ) = get_convhull_features(convex_hull_points)
 
     np.testing.assert_almost_equal(perimeters, 1458.8585933576614, decimal=3)
     np.testing.assert_almost_equal(areas, 23878.72090798154, decimal=3)
@@ -102,7 +117,7 @@ def test_get_convhull_rice(rice_h5):
 
 
 # test plant with 2 roots/instances with nan nodes
-def test_get_convhull_nan(pts_nan31_5node):
+def test_get_convhull_features_nan(pts_nan31_5node):
     (
         perimeters,
         areas,
@@ -111,7 +126,7 @@ def test_get_convhull_nan(pts_nan31_5node):
         median_dists,
         max_widths,
         max_heights,
-    ) = get_convhull(pts_nan31_5node)
+    ) = get_convhull_features(pts_nan31_5node)
 
     np.testing.assert_almost_equal(perimeters, 1184.6684128638494, decimal=3)
     np.testing.assert_almost_equal(areas, 2276.1159928281368, decimal=3)
@@ -123,7 +138,7 @@ def test_get_convhull_nan(pts_nan31_5node):
 
 
 # test plant with 1 root/instance with only 2 non-nan nodes
-def test_get_convhull_nanall(pts_nan_5node):
+def test_get_convhull_features_nanall(pts_nan_5node):
     (
         perimeters,
         areas,
@@ -132,7 +147,7 @@ def test_get_convhull_nanall(pts_nan_5node):
         median_dists,
         max_widths,
         max_heights,
-    ) = get_convhull(pts_nan_5node)
+    ) = get_convhull_features(pts_nan_5node)
 
     np.testing.assert_almost_equal(perimeters, np.nan, decimal=3)
     np.testing.assert_almost_equal(areas, np.nan, decimal=3)

--- a/tests/test_convhull.py
+++ b/tests/test_convhull.py
@@ -1,0 +1,143 @@
+from sleap_roots import Series
+from sleap_roots.convhull import get_convhull
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def pts_nan31_5node():
+    return np.array(
+        [
+            [
+                [852.17755127, 216.95648193],
+                [np.nan, np.nan],
+                [np.nan, np.nan],
+                [np.nan, np.nan],
+                [816.71142578, 808.12585449],
+            ],
+            [
+                [852.17755127, 216.95648193],
+                [np.nan, np.nan],
+                [837.03405762, 588.5123291],
+                [828.87963867, 692.72009277],
+                [816.71142578, 808.12585449],
+            ],
+        ]
+    )
+
+
+@pytest.fixture
+def pts_nan_5node():
+    return np.array(
+        [
+            [
+                [852.17755127, 216.95648193],
+                [np.nan, np.nan],
+                [np.nan, np.nan],
+                [np.nan, np.nan],
+                [816.71142578, 808.12585449],
+            ],
+        ]
+    )
+
+
+# test canola model
+def test_get_ellipse_canola(canola_h5):
+    series = Series.load(
+        canola_h5, primary_name="primary_multi_day", lateral_name="lateral_3_nodes"
+    )
+    primary, lateral = series[0]
+
+    primary_points = primary.numpy().reshape(-1, 2)
+    lateral_points = lateral.numpy().reshape(-1, 2)
+    convex_hull_points = np.concatenate((primary_points, lateral_points), axis=0)
+
+    (
+        perimeters,
+        areas,
+        longest_dists,
+        shortest_dists,
+        median_dists,
+        max_widths,
+        max_heights,
+    ) = get_convhull(convex_hull_points)
+
+    np.testing.assert_almost_equal(perimeters, 1910.0476127930017, decimal=3)
+    np.testing.assert_almost_equal(areas, 93255.32153574759, decimal=3)
+    np.testing.assert_almost_equal(longest_dists, 884.6450178192455, decimal=3)
+    np.testing.assert_almost_equal(shortest_dists, 185.15460001685398, decimal=3)
+    np.testing.assert_almost_equal(median_dists, 404.77175083902506, decimal=3)
+    np.testing.assert_almost_equal(max_widths, 211.279296875, decimal=3)
+    np.testing.assert_almost_equal(max_heights, 876.5622253417969, decimal=3)
+
+
+# test rice model
+def test_get_ellipse_rice(rice_h5):
+    series = Series.load(
+        rice_h5, primary_name="main_3do_6nodes", lateral_name="longest_3do_6nodes"
+    )
+    primary, lateral = series[0]
+
+    primary_points = primary.numpy().reshape(-1, 2)
+    lateral_points = lateral.numpy().reshape(-1, 2)
+    convex_hull_points = np.concatenate((primary_points, lateral_points), axis=0)
+
+    (
+        perimeters,
+        areas,
+        longest_dists,
+        shortest_dists,
+        median_dists,
+        max_widths,
+        max_heights,
+    ) = get_convhull(convex_hull_points)
+
+    np.testing.assert_almost_equal(perimeters, 1458.8585933576614, decimal=3)
+    np.testing.assert_almost_equal(areas, 23878.72090798154, decimal=3)
+    np.testing.assert_almost_equal(longest_dists, 720.0494276295367, decimal=3)
+    np.testing.assert_almost_equal(shortest_dists, 139.99063366108192, decimal=3)
+    np.testing.assert_almost_equal(median_dists, 480.1270688506847, decimal=3)
+    np.testing.assert_almost_equal(max_widths, 64.4229736328125, decimal=3)
+    np.testing.assert_almost_equal(max_heights, 720.0375061035156, decimal=3)
+
+
+# test plant with 2 roots/instances with nan nodes
+def test_get_ellipse_nan(pts_nan31_5node):
+    (
+        perimeters,
+        areas,
+        longest_dists,
+        shortest_dists,
+        median_dists,
+        max_widths,
+        max_heights,
+    ) = get_convhull(pts_nan31_5node)
+
+    np.testing.assert_almost_equal(perimeters, 1184.6684128638494, decimal=3)
+    np.testing.assert_almost_equal(areas, 2276.1159928281368, decimal=3)
+    np.testing.assert_almost_equal(longest_dists, 592.2322796929061, decimal=3)
+    np.testing.assert_almost_equal(shortest_dists, 104.52632471064256, decimal=3)
+    np.testing.assert_almost_equal(median_dists, 296.20807552792064, decimal=3)
+    np.testing.assert_almost_equal(max_widths, 35.46612548999997, decimal=3)
+    np.testing.assert_almost_equal(max_heights, 591.16937256, decimal=3)
+
+
+# test plant with 1 root/instance with only 2 non-nan nodes
+def test_get_ellipse_nanall(pts_nan_5node):
+    (
+        perimeters,
+        areas,
+        longest_dists,
+        shortest_dists,
+        median_dists,
+        max_widths,
+        max_heights,
+    ) = get_convhull(pts_nan_5node)
+
+    np.testing.assert_almost_equal(perimeters, np.nan, decimal=3)
+    np.testing.assert_almost_equal(areas, np.nan, decimal=3)
+    np.testing.assert_almost_equal(longest_dists, np.nan, decimal=3)
+    np.testing.assert_almost_equal(shortest_dists, np.nan, decimal=3)
+    np.testing.assert_almost_equal(median_dists, np.nan, decimal=3)
+    np.testing.assert_almost_equal(max_widths, np.nan, decimal=3)
+    np.testing.assert_almost_equal(max_heights, np.nan, decimal=3)


### PR DESCRIPTION
- Add `get_convhull` function.
- Test the function using canola and rice models, instance(s) with NaN nodes.