### PR TITLE
Fixed scanline

### DIFF
--- a/sleap_roots/scanline.py
+++ b/sleap_roots/scanline.py
@@ -36,14 +36,14 @@ def get_scanline_intersections(
             # filter out nan nodes
             pts_j = points[j][~np.isnan(points[j]).any(axis=1)]
             if pts_j.shape[0] > 1:
-                if line.intersects(LineString(points[j])):
-                    intersection_root = line.intersection(LineString(points[j]))
+                if line.intersects(LineString(pts_j)):
+                    intersection_root = line.intersection(LineString(pts_j))
                     intersection_line.append([intersection_root.x, intersection_root.y])
         intersection.append(intersection_line)
     return intersection
 
 
-def count_scaline_intersections(
+def count_scanline_intersections(
     pts: np.ndarray, depth: int = 1080, width: int = 2048, n_line: int = 50
 ) -> np.ndarray:
     """Get number of intersection points of roots and scan lines.

--- a/tests/test_scanline.py
+++ b/tests/test_scanline.py
@@ -1,7 +1,42 @@
 import pytest
 import numpy as np
 from sleap_roots import Series
-from sleap_roots.scanline import get_scanline_intersections, count_scaline_intersections
+from sleap_roots.scanline import (
+    get_scanline_intersections,
+    count_scanline_intersections,
+)
+
+
+@pytest.fixture
+def pts_3roots_with_nan():
+    return np.array(
+        [
+            [
+                [920.48862368, 267.57325711],
+                [908.88587777, 285.13679716],
+                [906.19049368, 308.02657426],
+                [900.85484007, 332.35722827],
+                [894.77714477, 353.2618793],
+                [np.nan, np.nan],
+            ],
+            [
+                [918.0094082, 248.52049295],
+                [875.89084055, 312.34001093],
+                [886.19983474, 408.7826485],
+                [892.15722656, 492.16012042],
+                [899.53514073, 576.43033348],
+                [908.02496338, 668.82440186],
+            ],
+            [
+                [939.49111908, 291.1798956],
+                [938.01029766, 309.0299704],
+                [938.39169586, 324.6796079],
+                [939.44596587, 339.22885535],
+                [939.13551705, 355.82854929],
+                [938.88545817, 371.64891802],
+            ],
+        ]
+    )
 
 
 @pytest.fixture
@@ -63,7 +98,17 @@ def test_get_scanline_intersections_nan(pts_nan3):
     np.testing.assert_almost_equal(intersection[1], [], decimal=7)
 
 
-def test_count_scaline_intersections_canola(canola_h5):
+def test_get_scanline_intersections_3roots_nan(pts_3roots_with_nan):
+    pts = pts_3roots_with_nan
+    depth = 1080
+    width = 2048
+    n_line = 50
+    intersection = get_scanline_intersections(pts, depth, width, n_line)
+    assert len(intersection) == 50
+    np.testing.assert_almost_equal(intersection[1], [], decimal=7)
+
+
+def test_count_scanline_intersections_canola(canola_h5):
     series = Series.load(
         canola_h5, primary_name="primary_multi_day", lateral_name="lateral_3_nodes"
     )
@@ -72,12 +117,12 @@ def test_count_scaline_intersections_canola(canola_h5):
     depth = 1080
     width = 2048
     n_line = 50
-    n_inter = count_scaline_intersections(pts, depth, width, n_line)
+    n_inter = count_scanline_intersections(pts, depth, width, n_line)
     assert n_inter.shape == (50,)
     np.testing.assert_equal(n_inter[14], 1)
 
 
-def test_count_scaline_intersections_rice(rice_h5):
+def test_count_scanline_intersections_rice(rice_h5):
     series = Series.load(
         rice_h5, primary_name="main_3do_6nodes", lateral_name="longest_3do_6nodes"
     )
@@ -88,16 +133,26 @@ def test_count_scaline_intersections_rice(rice_h5):
     width = 2048
     n_line = 50
 
-    n_inter = count_scaline_intersections(pts, depth, width, n_line)
+    n_inter = count_scanline_intersections(pts, depth, width, n_line)
     assert n_inter.shape == (50,)
     np.testing.assert_equal(n_inter[14], 2)
 
 
-def test_count_scaline_intersections_nan(pts_nan3):
+def test_count_scanline_intersections_nan(pts_nan3):
     pts = pts_nan3
     depth = 1080
     width = 2048
     n_line = 50
-    n_inter = count_scaline_intersections(pts, depth, width, n_line)
+    n_inter = count_scanline_intersections(pts, depth, width, n_line)
     assert len(n_inter) == 50
     np.testing.assert_equal(n_inter[14], 0)
+
+
+def test_count_scanline_intersections_3roots_nan(pts_3roots_with_nan):
+    pts = pts_3roots_with_nan
+    depth = 1080
+    width = 2048
+    n_line = 50
+    n_inter = count_scanline_intersections(pts, depth, width, n_line)
+    assert len(n_inter) == 50
+    np.testing.assert_equal(n_inter[14], 3)


### PR DESCRIPTION
- Changed `get_scanline_intersections` so NaN nodes are removed (pts_j).
- Added fixture `pts_3roots_with_nan` which gave error with previous scanline function. 
- Added test `test_count_scanline_intersections_3roots_nan`.
- Changed name to `count_scanline_intersections` instead of count_scaline_intersections. 