### PR TITLE
Modify scanline functions for monocots.

### DIFF
--- a/sleap_roots/scanline.py
+++ b/sleap_roots/scanline.py
@@ -28,7 +28,7 @@ def count_scanline_intersections(
     """
     # connect the points to lines using shapely
     if monocots:
-        points = list(primary_pts)
+        points = list(lateral_pts)
     else:
         points = list(primary_pts) + list(lateral_pts)
 
@@ -41,7 +41,7 @@ def count_scanline_intersections(
         horizontal_line_y = n_interval * (i + 1)
         intersection_line = 0
 
-        for j in range(len(points) - 1):
+        for j in range(len(points)):
             intersection_counts_root = 0
             # filter out nan nodes
             pts_j = np.array(points[j])[~np.isnan(points[j]).any(axis=1)]

--- a/tests/test_scanline.py
+++ b/tests/test_scanline.py
@@ -122,4 +122,4 @@ def test_get_scanline_last_ind(canola_h5):
     scanline_last_ind = get_scanline_last_ind(
         primary_pts, lateral_pts, depth, width, n_line, monocots
     )
-    np.testing.assert_equal(scanline_last_ind, np.nan)
+    np.testing.assert_equal(scanline_last_ind, 15)


### PR DESCRIPTION
- In function `count_scanline_intersections`, use lateral_pts (main roots) for to calculate monocot traits
- In function `count_scanline_intersections`, use all lateral roots to calculate scanline-related traits
- fixes #42 