### PR TITLE
Speedup pipelining by add cache dict of scanline-, ellipse-, and chull-related traits

### DIFF
--- a/sleap_roots/convhull.py
+++ b/sleap_roots/convhull.py
@@ -5,6 +5,8 @@ from scipy.spatial import ConvexHull, convex_hull_plot_2d
 from scipy.spatial.distance import pdist
 from typing import Tuple, Optional, Union
 
+cache = {}
+
 
 def get_convhull(pts: np.ndarray) -> Optional[ConvexHull]:
     """Get the convex hull for the points per frame.
@@ -23,7 +25,7 @@ def get_convhull(pts: np.ndarray) -> Optional[ConvexHull]:
 
     # Get convex hull
     hull = ConvexHull(pts)
-
+    cache["hull"] = hull
     return hull
 
 
@@ -44,7 +46,12 @@ def get_convhull_features(
 
         If the convex hull fitting fails, NaNs are returned.
     """
-    hull = pts if type(pts) == ConvexHull else get_convhull(pts)
+    if type(pts) == ConvexHull:
+        hull = pts
+    elif "hull" in cache:
+        hull = cache["hull"]
+    else:
+        hull = get_convhull(pts)
 
     if hull is None:
         return np.full((4,), np.nan)
@@ -85,8 +92,11 @@ def get_chull_perimeter(
         return pts[0]
     elif type(pts) == ConvexHull:
         hull = pts
+    elif "hull" in cache:
+        hull = cache["hull"]
     else:
         hull = get_convhull(pts)
+
     if hull is None:
         return np.nan
     return hull.area
@@ -107,8 +117,11 @@ def get_chull_area(
         return pts[1]
     elif type(pts) == ConvexHull:
         hull = pts
+    elif "hull" in cache:
+        hull = cache["hull"]
     else:
         hull = get_convhull(pts)
+
     if hull is None:
         return np.nan
     return hull.volume
@@ -129,8 +142,11 @@ def get_chull_max_width(
         return pts[2]
     elif type(pts) == ConvexHull:
         hull = pts
+    elif "hull" in cache:
+        hull = cache["hull"]
     else:
         hull = get_convhull(pts)
+
     if hull is None:
         return np.nan
     pts = pts.reshape(-1, 2)
@@ -154,8 +170,11 @@ def get_chull_max_height(
         return pts[3]
     elif type(pts) == ConvexHull:
         hull = pts
+    elif "hull" in cache:
+        hull = cache["hull"]
     else:
         hull = get_convhull(pts)
+
     if hull is None:
         return np.nan
     pts = pts.reshape(-1, 2)
@@ -174,7 +193,12 @@ def get_chull_line_lengths(pts: Union[np.ndarray, ConvexHull]) -> np.ndarray:
         Lengths of lines connecting any two vertices on the convex hull.
         If the convex hull fitting fails, NaNs are returned.
     """
-    hull = pts if type(pts) == ConvexHull else get_convhull(pts)
+    if type(pts) == ConvexHull:
+        hull = pts
+    elif "hull" in cache:
+        hull = cache["hull"]
+    else:
+        hull = get_convhull(pts)
 
     if hull is None:
         return np.nan

--- a/sleap_roots/convhull.py
+++ b/sleap_roots/convhull.py
@@ -21,12 +21,13 @@ def get_convhull(pts: np.ndarray) -> Optional[ConvexHull]:
     pts = pts[~(np.isnan(pts).any(axis=-1))]
 
     if len(pts) <= 2:
+        cache["hull"] = None
         return None
-
-    # Get convex hull
-    hull = ConvexHull(pts)
-    cache["hull"] = hull
-    return hull
+    else:
+        # Get convex hull
+        hull = ConvexHull(pts)
+        cache["hull"] = hull
+        return hull
 
 
 def get_convhull_features(

--- a/sleap_roots/ellipse.py
+++ b/sleap_roots/ellipse.py
@@ -5,6 +5,9 @@ from skimage.measure import EllipseModel
 from typing import Tuple, Union
 
 
+cache = {}
+
+
 def fit_ellipse(pts: np.ndarray) -> Tuple[float, float, float]:
     """Find a best fit ellipse for the points per frame.
 
@@ -31,6 +34,7 @@ def fit_ellipse(pts: np.ndarray) -> Tuple[float, float, float]:
         xc, yc, a_f, b_f, theta = ell.params
         a_f, b_f = np.maximum(a_f, b_f), np.minimum(a_f, b_f)
         ratio_ba_f = a_f / b_f
+        cache["ellipse_features"] = [a_f, b_f, ratio_ba_f]
         return a_f, b_f, ratio_ba_f
     else:
         return np.nan, np.nan, np.nan
@@ -47,9 +51,11 @@ def get_ellipse_a(pts_all_array: Union[np.ndarray, Tuple[float, float, float]]):
     """
     if type(pts_all_array) == tuple:
         ellipse_a = pts_all_array[0]
+    elif "ellipse_features" in cache:
+        ellipse_features = cache["ellipse_features"]
     else:
         ellipse_features = fit_ellipse(pts_all_array)
-        ellipse_a = ellipse_features[0]
+    ellipse_a = ellipse_features[0]
     return ellipse_a
 
 
@@ -64,9 +70,11 @@ def get_ellipse_b(pts_all_array: Union[np.ndarray, Tuple[float, float, float]]):
     """
     if type(pts_all_array) == tuple:
         ellipse_b = pts_all_array[1]
+    elif "ellipse_features" in cache:
+        ellipse_features = cache["ellipse_features"]
     else:
         ellipse_features = fit_ellipse(pts_all_array)
-        ellipse_b = ellipse_features[1]
+    ellipse_b = ellipse_features[1]
     return ellipse_b
 
 
@@ -81,7 +89,9 @@ def get_ellipse_ratio(pts_all_array: Union[np.ndarray, Tuple[float, float, float
     """
     if type(pts_all_array) == tuple:
         ellipse_ratio = pts_all_array[2]
+    elif "ellipse_features" in cache:
+        ellipse_features = cache["ellipse_features"]
     else:
         ellipse_features = fit_ellipse(pts_all_array)
-        ellipse_ratio = ellipse_features[2]
+    ellipse_ratio = ellipse_features[2]
     return ellipse_ratio

--- a/sleap_roots/graphpipeline.py
+++ b/sleap_roots/graphpipeline.py
@@ -29,7 +29,7 @@ from sleap_roots.convhull import (
     get_chull_max_width,
     get_chull_max_height,
     get_chull_perimeter,
-    get_convhull_features,
+    get_convhull,
 )
 from sleap_roots.ellipse import (
     fit_ellipse,
@@ -184,7 +184,7 @@ def get_traits_value_frame(
             [lateral_pts, primary_pts, stem_width_tolerance, monocots],
         ),
         # get_convhull_features(pts: Union[np.ndarray, ConvexHull]) -> Tuple[float, float, float, float]
-        "convex_hull": (get_convhull_features, [pts_all_array]),
+        "convex_hull": (get_convhull, [pts_all_array]),
         # get_lateral_count(pts: np.ndarray)
         "lateral_count": (get_lateral_count, [lateral_pts]),
         # # get_root_angle(pts: np.ndarray, proximal=True, base_ind=0) -> np.ndarray
@@ -279,6 +279,7 @@ def get_traits_value_frame(
 
     dts = get_traits_graph()
 
+    cache = {}
     data = {}
     for trait_name in dts:
         fn, inputs = trait_map[trait_name]

--- a/sleap_roots/graphpipeline.py
+++ b/sleap_roots/graphpipeline.py
@@ -690,6 +690,7 @@ def get_all_plants_traits(
 
     all_traits = []
     for h5 in h5_series:
+        cache = {}
         plant_traits = get_traits_value_plant_summary(
             h5,
             monocots=monocots,

--- a/sleap_roots/networklength.py
+++ b/sleap_roots/networklength.py
@@ -3,7 +3,7 @@
 import numpy as np
 from shapely import LineString, Polygon
 from sleap_roots.bases import get_root_lengths
-from sleap_roots.convhull import get_convhull_features
+from sleap_roots.convhull import get_chull_area
 from typing import Tuple
 
 
@@ -76,8 +76,7 @@ def get_network_solidity(
     network_length = get_network_length(primary_pts, lateral_pts, monocots)
 
     # get the convex hull area
-    convhull_features = get_convhull_features(pts_all_array)
-    conv_area = convhull_features[1]
+    conv_area = get_chull_area(pts_all_array)
 
     if network_length > 0 and conv_area > 0:
         ratio = network_length / conv_area

--- a/sleap_roots/scanline.py
+++ b/sleap_roots/scanline.py
@@ -4,6 +4,8 @@ import numpy as np
 import math
 from shapely import LineString, Point
 
+cache = {}
+
 
 def count_scanline_intersections(
     primary_pts: np.ndarray,
@@ -57,6 +59,7 @@ def count_scanline_intersections(
                 intersection_counts_root += current_root
             intersection_line += intersection_counts_root
         intersection.append(intersection_line)
+    cache["count_scanline_interaction"] = np.array(intersection)
     return np.array(intersection)
 
 
@@ -81,9 +84,12 @@ def get_scanline_first_ind(
     Return:
         Scalar of count_scanline_interaction index for the first interaction.
     """
-    count_scanline_interaction = count_scanline_intersections(
-        primary_pts, lateral_pts, depth, width, n_line, monocots
-    )
+    if "count_scanline_interaction" in cache:
+        count_scanline_interaction = cache["count_scanline_interaction"]
+    else:
+        count_scanline_interaction = count_scanline_intersections(
+            primary_pts, lateral_pts, depth, width, n_line, monocots
+        )
     if np.where((count_scanline_interaction > 0))[0].shape[0] > 0:
         scanline_first_ind = np.where((count_scanline_interaction > 0))[0][0]
         return scanline_first_ind
@@ -112,9 +118,13 @@ def get_scanline_last_ind(
     Return:
         Scalar of count_scanline_interaction index for the last interaction.
     """
-    count_scanline_interaction = count_scanline_intersections(
-        primary_pts, lateral_pts, depth, width, n_line, monocots
-    )
+    # LW
+    if "count_scanline_interaction" in cache:
+        count_scanline_interaction = cache["count_scanline_interaction"]
+    else:
+        count_scanline_interaction = count_scanline_intersections(
+            primary_pts, lateral_pts, depth, width, n_line, monocots
+        )
     if np.where((count_scanline_interaction > 0))[0].shape[0] > 0:
         scanline_last_ind = np.where((count_scanline_interaction > 0))[0][-1]
         return scanline_last_ind

--- a/tests/test_convhull.py
+++ b/tests/test_convhull.py
@@ -121,6 +121,7 @@ def test_get_convhull_features_rice(rice_h5):
     primary_points = primary.numpy().reshape(-1, 2)
     lateral_points = lateral.numpy().reshape(-1, 2)
     convex_hull_points = np.concatenate((primary_points, lateral_points), axis=0)
+    convex_hull = get_convhull(convex_hull_points)
 
     (
         perimeters,
@@ -137,6 +138,7 @@ def test_get_convhull_features_rice(rice_h5):
 
 # test plant with 2 roots/instances with nan nodes
 def test_get_convhull_features_nan(pts_nan31_5node):
+    convex_hull = get_convhull(pts_nan31_5node)
     (
         perimeters,
         areas,
@@ -152,6 +154,7 @@ def test_get_convhull_features_nan(pts_nan31_5node):
 
 # test plant with 1 root/instance with only 2 non-nan nodes
 def test_get_convhull_features_nanall(pts_nan_5node):
+    convex_hull = get_convhull(pts_nan_5node)
     (
         perimeters,
         areas,
@@ -167,6 +170,7 @@ def test_get_convhull_features_nanall(pts_nan_5node):
 
 # test get_chull_perimeter with defined lateral_pts
 def test_get_chull_perimeter(lateral_pts):
+    convex_hull = get_convhull(lateral_pts)
     perimeter = get_chull_perimeter(lateral_pts)
     np.testing.assert_almost_equal(perimeter, 1184.7141710619985, decimal=3)
 
@@ -177,6 +181,7 @@ def test_get_chull_perimeter_canola(canola_h5):
         canola_h5, primary_name="primary_multi_day", lateral_name="lateral_3_nodes"
     )
     pts = get_all_pts_array(plant=plant, frame=0, monocots=False)
+    convex_hull = get_convhull(pts)
     perimeter = get_chull_perimeter(pts)
     np.testing.assert_almost_equal(perimeter, 1910.0476127930017, decimal=3)
 
@@ -187,6 +192,7 @@ def test_get_chull_area_canola(canola_h5):
         canola_h5, primary_name="primary_multi_day", lateral_name="lateral_3_nodes"
     )
     pts = get_all_pts_array(plant=plant, frame=0, monocots=False)
+    convex_hull = get_convhull(pts)
     area = get_chull_area(pts)
     np.testing.assert_almost_equal(area, 93255.32153574759, decimal=3)
 
@@ -216,6 +222,7 @@ def test_get_chull_line_lengths(canola_h5):
         canola_h5, primary_name="primary_multi_day", lateral_name="lateral_3_nodes"
     )
     pts = get_all_pts_array(plant=plant, frame=0, monocots=False)
+    convex_hull = get_convhull(pts)
     chull_line_lengths = get_chull_line_lengths(pts)
     assert chull_line_lengths.shape[0] == 10
     np.testing.assert_almost_equal(chull_line_lengths[0], 227.553, decimal=3)
@@ -223,5 +230,6 @@ def test_get_chull_line_lengths(canola_h5):
 
 # test get_chull_line_lengths with none hull
 def test_get_chull_line_lengths_nonehull(pts_nan_5node):
+    convex_hull = get_convhull(pts_nan_5node)
     chull_line_lengths = get_chull_line_lengths(pts_nan_5node)
     np.testing.assert_almost_equal(chull_line_lengths, np.nan, decimal=3)

--- a/tests/test_ellipse.py
+++ b/tests/test_ellipse.py
@@ -37,6 +37,7 @@ def test_get_ellipse_a(canola_h5):
         canola_h5, primary_name="primary_multi_day", lateral_name="lateral_3_nodes"
     )
     pts_all_array = get_all_pts_array(plant=plant, frame=0, monocots=False)
+    a, b, ratio = fit_ellipse(pts_all_array)
     ellipse_a = get_ellipse_a(pts_all_array)
     np.testing.assert_almost_equal(ellipse_a, 398.1275346610801, decimal=3)
 

--- a/tests/test_graphpipeline.py
+++ b/tests/test_graphpipeline.py
@@ -134,6 +134,11 @@ def tests_get_all_plants_traits_monocot(rice_folder):
         lateral_name=lateral_name,
         write_per_plant_details=write_per_plant_details,
         write_per_plant_summary=write_per_plant_summary,
+        monocots=True,
     )
     assert all_traits_df.shape == (1, 1037)
     np.testing.assert_almost_equal(all_traits_df.iloc[0, 5], 3.716619501198254)
+    np.testing.assert_almost_equal(all_traits_df["ellipse_a_max"][0], 373.4706668836014)
+    np.testing.assert_almost_equal(
+        all_traits_df["chull_area_max"][0], 34719.249469074435
+    )

--- a/tests/test_networklength.py
+++ b/tests/test_networklength.py
@@ -103,7 +103,6 @@ def test_get_network_solidity_rice(rice_h5):
     lateral_pts = lateral.numpy()
     pts_all_array = get_all_pts_array(plant=series, frame=0, monocots=True)
     monocots = True
-    cache = {}
     ratio = get_network_solidity(primary_pts, lateral_pts, pts_all_array, monocots)
     np.testing.assert_almost_equal(ratio, 0.17930631242462894, decimal=7)
 

--- a/tests/test_networklength.py
+++ b/tests/test_networklength.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 from sleap_roots import Series
+from sleap_roots.convhull import get_convhull
 from sleap_roots.networklength import get_bbox
 from sleap_roots.networklength import get_network_distribution
 from sleap_roots.networklength import get_network_distribution_ratio
@@ -81,7 +82,7 @@ def test_get_network_width_depth_ratio_nan(pts_nan3):
     np.testing.assert_almost_equal(ratio, np.nan, decimal=7)
 
 
-def test_get_network_solidity(canola_h5):
+def test_get_network_solidity_canola(canola_h5, cache):
     series = Series.load(
         canola_h5, primary_name="primary_multi_day", lateral_name="lateral_3_nodes"
     )
@@ -90,6 +91,7 @@ def test_get_network_solidity(canola_h5):
     lateral_pts = lateral.numpy()
     pts_all_array = get_all_pts_array(plant=series, frame=0, monocots=False)
     monocots = False
+    convex_hull = get_convhull(pts_all_array)
     ratio = get_network_solidity(primary_pts, lateral_pts, pts_all_array, monocots)
     np.testing.assert_almost_equal(ratio, 0.012578941125511587, decimal=7)
 
@@ -103,6 +105,7 @@ def test_get_network_solidity_rice(rice_h5):
     lateral_pts = lateral.numpy()
     pts_all_array = get_all_pts_array(plant=series, frame=0, monocots=True)
     monocots = True
+    convex_hull = get_convhull(pts_all_array)
     ratio = get_network_solidity(primary_pts, lateral_pts, pts_all_array, monocots)
     np.testing.assert_almost_equal(ratio, 0.17930631242462894, decimal=7)
 

--- a/tests/test_networklength.py
+++ b/tests/test_networklength.py
@@ -103,6 +103,7 @@ def test_get_network_solidity_rice(rice_h5):
     lateral_pts = lateral.numpy()
     pts_all_array = get_all_pts_array(plant=series, frame=0, monocots=True)
     monocots = True
+    cache = {}
     ratio = get_network_solidity(primary_pts, lateral_pts, pts_all_array, monocots)
     np.testing.assert_almost_equal(ratio, 0.17930631242462894, decimal=7)
 

--- a/tests/test_scanline.py
+++ b/tests/test_scanline.py
@@ -101,6 +101,9 @@ def test_get_scanline_first_ind(canola_h5):
     width = 2048
     n_line = 50
     monocots = False
+    n_inter = count_scanline_intersections(
+        primary_pts, lateral_pts, depth, width, n_line, monocots
+    )
     scanline_first_ind = get_scanline_first_ind(
         primary_pts, lateral_pts, depth, width, n_line, monocots
     )
@@ -118,8 +121,11 @@ def test_get_scanline_last_ind(canola_h5):
     depth = 1080
     width = 2048
     n_line = 50
-    monocots = True
+    monocots = False
+    n_inter = count_scanline_intersections(
+        primary_pts, lateral_pts, depth, width, n_line, monocots
+    )
     scanline_last_ind = get_scanline_last_ind(
         primary_pts, lateral_pts, depth, width, n_line, monocots
     )
-    np.testing.assert_equal(scanline_last_ind, 15)
+    np.testing.assert_equal(scanline_last_ind, 43)


### PR DESCRIPTION
- Add cache dictionary of each plant in `get_all_plants_traits` function and the following functions
   - all chull-related functions, and `get_network_solidity` (used get_chull_area function)
   - all ellipse-related functions
   - all scanline-related functions
- Modify get_convhull function for edge condition (len(pts) <= 2)
- New cache dictionary (cache = {}) when start each frame
- testing functions: add the function which appending results to the cache dictionary for the test functions of different dataset
  - For example, if the last test case was canola, the current test case is rice, add `get_convhull` function when test the convex hull area of rice. This will make sure the last cache dictionary won't carry out to this test.
- fixes #35 