### PR TITLE
Fixes for dicot pipeline

### DIFF
--- a/sleap_roots/bases.py
+++ b/sleap_roots/bases.py
@@ -86,51 +86,34 @@ def get_lateral_count(pts: np.ndarray):
     return lateral_count
 
 
-def get_base_xs(pts: np.ndarray, monocots: bool = False) -> np.ndarray:
+def get_base_xs(base_pts: np.ndarray) -> np.ndarray:
     """Get x coordinates of the base of each lateral root.
 
     Args:
-        pts: root landmarks as array of shape `(instances, point, 2)` or bases
-            `(instances, 2)`.
-        monocots: Boolean value, where false is dicot (default), true is rice.
+        base_pts: Array of bases as returned by `get_bases`, shape `(instances, 2)` or 
+            `(2,)`.
 
-    Return:
-        An array of the x-coordinates of bases `(instance,)`.
+    Returns:
+        An array of the x-coordinates of bases `(instances,)` or a single x-coordinate.
     """
     # If the input is a single number (float or integer), return np.nan
-    if isinstance(pts, (np.floating, float, np.integer, int)):
+    if isinstance(base_pts, (np.floating, float, np.integer, int)):
         return np.nan
 
-    # If the input array doesn't have 2 or 3 dimensions, raise an error
-    if pts.ndim not in (2, 3):
-        raise ValueError(
-            "Input array must be 2-dimensional (n_bases, 2) or "
-            "3-dimensional (n_roots, n_nodes, 2)."
-        )
-
-    # If the input array has 3 dimensions, calculate the base points,
-    # otherwise, assume the input array already contains the base points
-    if pts.ndim == 3:
-        _base_pts = get_bases(
-            pts, monocots
-        )  # Assuming get_bases returns an array of shape (instance, 2)
-    else:
-        _base_pts = pts
-
-    # If _base_pts is a single number (float or integer), return np.nan
-    if isinstance(_base_pts, (np.floating, float, np.integer, int)):
-        return np.nan
+    # If the base points array has shape `(2,)`, return the first element (x)
+    if base_pts.ndim == 1 and base_pts.shape[0] == 2:
+        return base_pts[0]
 
     # If the base points array doesn't have exactly 2 dimensions or
     # the second dimension is not of size 2, raise an error
-    if _base_pts.ndim != 2 or _base_pts.shape[1] != 2:
+    elif base_pts.ndim != 2 or base_pts.shape[1] != 2:
         raise ValueError(
-            "Array of base points must be 2-dimensional with shape (instance, 2)."
+            "Array of base points must be 2-dimensional with shape (instances, 2)."
         )
 
     # If everything is fine, extract and return the x-coordinates of the base points
     else:
-        base_xs = _base_pts[:, 0]
+        base_xs = base_pts[:, 0]
         return base_xs
 
 

--- a/sleap_roots/bases.py
+++ b/sleap_roots/bases.py
@@ -90,7 +90,7 @@ def get_base_xs(base_pts: np.ndarray) -> np.ndarray:
     """Get x coordinates of the base of each lateral root.
 
     Args:
-        base_pts: Array of bases as returned by `get_bases`, shape `(instances, 2)` or 
+        base_pts: Array of bases as returned by `get_bases`, shape `(instances, 2)` or
             `(2,)`.
 
     Returns:
@@ -173,14 +173,17 @@ def get_base_ct_density(
 
     Args:
         primary_length_max: Scalar of maximum primary root length.
-        lateral_base_pts: Base points of lateral roots as returned by `get_bases`, 
+        lateral_base_pts: Base points of lateral roots as returned by `get_bases`,
             shape `(instances, 2)` or `(2,)`.
 
     Return:
         Scalar of base count density.
     """
     # Check if the input is invalid
-    if isinstance(lateral_base_pts, (np.floating, float, np.integer, int)) or np.isnan(lateral_base_pts).all():
+    if (
+        isinstance(lateral_base_pts, (np.floating, float, np.integer, int))
+        or np.isnan(lateral_base_pts).all()
+    ):
         return np.nan
 
     # Handle the case where lateral_base_pts has shape `(2,)`

--- a/sleap_roots/bases.py
+++ b/sleap_roots/bases.py
@@ -167,28 +167,29 @@ def get_base_length(lateral_base_ys: np.ndarray, monocots: bool = False) -> floa
 
 
 def get_base_ct_density(
-    primary_length_max: float, lateral_base_pts: np.ndarray, monocots: bool = False
-):
+    primary_length_max: float, lateral_base_pts: np.ndarray
+) -> float:
     """Get a ratio of the number of base points to maximum primary root length.
 
     Args:
         primary_length_max: Scalar of maximum primary root length.
-        lateral_base_pts: Base points of lateral roots of shape (instances, 2).
-        monocots: Boolean value, where false is dicot (default), true is rice.
+        lateral_base_pts: Base points of lateral roots as returned by `get_bases`, 
+            shape `(instances, 2)` or `(2,)`.
 
     Return:
         Scalar of base count density.
     """
-    # Check if the input is valid for lateral_base_pts or if monocots is True
-    if (
-        monocots
-        or isinstance(lateral_base_pts, (np.floating, float, np.integer, int))
-        or np.isnan(lateral_base_pts).all()
-    ):
+    # Check if the input is invalid
+    if isinstance(lateral_base_pts, (np.floating, float, np.integer, int)) or np.isnan(lateral_base_pts).all():
         return np.nan
 
-    # Get the number of base points of lateral roots
-    base_ct = len(lateral_base_pts[~np.isnan(lateral_base_pts[:, 0])])
+    # Handle the case where lateral_base_pts has shape `(2,)`
+    if lateral_base_pts.ndim == 1 and lateral_base_pts.shape[0] == 2:
+        base_ct = 1  # Only one base point in this case
+
+    # Handle the case where lateral_base_pts has shape `(instances, 2)`
+    else:
+        base_ct = len(lateral_base_pts[~np.isnan(lateral_base_pts[:, 0])])
 
     # Handle cases where maximum primary length is zero or NaN to avoid division by zero
     if primary_length_max == 0 or np.isnan(primary_length_max):

--- a/sleap_roots/tips.py
+++ b/sleap_roots/tips.py
@@ -29,36 +29,35 @@ def get_tips(pts: np.ndarray) -> np.ndarray:
     return tip_pts
 
 
-def get_tip_xs(pts: np.ndarray) -> np.ndarray:
-    """Get x coordinates of tip points.
+def get_tip_xs(tip_pts: np.ndarray) -> np.ndarray:
+    """Get x coordinates of the tips of each lateral root.
 
     Args:
-        pts: Root landmarks as array of shape (instances, nodes, 2) or tips
-            (instances, 2).
+        tip_pts: Array of tips as returned by `get_tips`, shape `(instances, 2)` or 
+            `(2,)`.
 
-    Return:
-        An array of tip x-coordinates (instances,).
+    Returns:
+        An array of the x-coordinates of tips `(instances,)` or a single x-coordinate.
     """
-    if pts.ndim not in (2, 3):
-        raise ValueError(
-            "Input array must be 2-dimensional (n_tips, 2) or "
-            "3-dimensional (n_roots, n_nodes, 2)."
-        )
+    # If the input is a single number (float or integer), return np.nan
+    if isinstance(tip_pts, (np.floating, float, np.integer, int)):
+        return np.nan
 
-    if pts.ndim == 3:
-        _tip_pts = get_tips(
-            pts
-        )  # Assuming get_tips returns an array of shape (instance, 2)
-    else:
-        _tip_pts = pts
+    # If the tip points array has shape `(2,)`, return the first element
+    if tip_pts.ndim == 1 and tip_pts.shape[0] == 2:
+        return tip_pts[0]
 
-    if _tip_pts.ndim != 2 or _tip_pts.shape[1] != 2:
+    # If the tip points array doesn't have exactly 2 dimensions or
+    # the second dimension is not of size 2, raise an error
+    elif tip_pts.ndim != 2 or tip_pts.shape[1] != 2:
         raise ValueError(
             "Array of tip points must be 2-dimensional with shape (instances, 2)."
         )
 
-    tip_xs = _tip_pts[:, 0]
-    return tip_xs
+    # If everything is fine, extract and return the x-coordinates of the tip points
+    else:
+        tip_xs = tip_pts[:, 0]
+        return tip_xs
 
 
 def get_tip_ys(tip_pts: np.ndarray) -> np.ndarray:

--- a/sleap_roots/tips.py
+++ b/sleap_roots/tips.py
@@ -29,46 +29,50 @@ def get_tips(pts: np.ndarray) -> np.ndarray:
     return tip_pts
 
 
-def get_tip_xs(tip_pts: np.ndarray) -> np.ndarray:
-    """Get x coordinates of the tips of each lateral root.
+def get_tip_xs(tip_pts: np.ndarray, flatten: bool = False) -> np.ndarray:
+    """Get x coordinates of tip points.
 
     Args:
-        tip_pts: Array of tips as returned by `get_tips`, shape `(instances, 2)` or 
-            `(2,)`.
+        tip_pts: Root tips as array of shape `(instances, 2)` or `(2)` when there is
+            only one tip.
+        flatten: If `True`, return scalar (0-D) array if scalar (there is only 1 root).
+            Defaults to `False`.
 
     Returns:
-        An array of the x-coordinates of tips `(instances,)` or a single x-coordinate.
+        An array of the x-coordinates of tips (instances,) or () if `flatten` is `True`.
     """
-    # If the input is a single number (float or integer), return np.nan
+    # If the input is a single number (float or integer), raise an error
     if isinstance(tip_pts, (np.floating, float, np.integer, int)):
-        return np.nan
+        raise ValueError("Input must be an array of shape `(instances, 2)` or `(2, )`.")
 
-    # If the tip points array has shape `(2,)`, return the first element
-    if tip_pts.ndim == 1 and tip_pts.shape[0] == 2:
-        return tip_pts[0]
+    # Check for the 2D shape of the input array
+    if tip_pts.ndim == 1:
+        # If shape is `(2,)`, then reshape it to `(1, 2)` for consistency
+        tip_pts = tip_pts.reshape(1, 2)
+    elif tip_pts.ndim != 2:
+        raise ValueError("Input array must be of shape `(instances, 2)` or `(2, )`.")
 
-    # If the tip points array doesn't have exactly 2 dimensions or
-    # the second dimension is not of size 2, raise an error
-    elif tip_pts.ndim != 2 or tip_pts.shape[1] != 2:
-        raise ValueError(
-            "Array of tip points must be 2-dimensional with shape (instances, 2)."
-        )
+    # At this point, `tip_pts` should be of shape `(instances, 2)`.
+    tip_xs = tip_pts[:, 0]
 
-    # If everything is fine, extract and return the x-coordinates of the tip points
-    else:
-        tip_xs = tip_pts[:, 0]
-        return tip_xs
+    if flatten:
+        tip_xs = tip_xs.squeeze()
+        if tip_xs.size == 1:
+            tip_xs = tip_xs[()]
+    return tip_xs
 
 
-def get_tip_ys(tip_pts: np.ndarray) -> np.ndarray:
+def get_tip_ys(tip_pts: np.ndarray, flatten: bool = False) -> np.ndarray:
     """Get y coordinates of tip points.
 
     Args:
-        tip_pts: Root tips as array of shape `(instances, 2)` or `(2)`
-            when there is only one tip.
+        tip_pts: Root tips as array of shape `(instances, 2)` or `(2)` when there is
+            only one tip.
+        flatten: If `True`, return scalar (0-D) array if scalar (there is only 1 root).
+            Defaults to `False`.
 
     Return:
-        An array of the y-coordinates of tips (instances,).
+        An array of the y-coordinates of tips (instances,) or () if `flatten` is `True`.
     """
     # If the input is a single number (float or integer), raise an error
     if isinstance(tip_pts, (np.floating, float, np.integer, int)):
@@ -83,4 +87,9 @@ def get_tip_ys(tip_pts: np.ndarray) -> np.ndarray:
 
     # At this point, `tip_pts` should be of shape `(instances, 2)`.
     tip_ys = tip_pts[:, 1]
+
+    if flatten:
+        tip_ys = tip_ys.squeeze()
+        if tip_ys.size == 1:
+            tip_ys = tip_ys[()]
     return tip_ys

--- a/sleap_roots/trait_pipelines.py
+++ b/sleap_roots/trait_pipelines.py
@@ -363,13 +363,9 @@ class Pipeline:
             # Summarize frame level traits.
             plant_summary = {"plant_name": plant.series_name}
             for trait_name in self.csv_traits:
-                try:
-                    trait_summary = get_summary(
-                        plant_traits[trait_name], prefix=f"{trait_name}_"
-                    )
-                except AttributeError:
-                    print(f"Issue computing summary for: {plant.series_name}/{trait_name} ({plant_traits[trait_name]})")
-                    raise
+                trait_summary = get_summary(
+                    plant_traits[trait_name], prefix=f"{trait_name}_"
+                )
                 plant_summary.update(trait_summary)
             all_traits.append(plant_summary)
 

--- a/sleap_roots/trait_pipelines.py
+++ b/sleap_roots/trait_pipelines.py
@@ -363,9 +363,13 @@ class Pipeline:
             # Summarize frame level traits.
             plant_summary = {"plant_name": plant.series_name}
             for trait_name in self.csv_traits:
-                trait_summary = get_summary(
-                    plant_traits[trait_name], prefix=f"{trait_name}_"
-                )
+                try:
+                    trait_summary = get_summary(
+                        plant_traits[trait_name], prefix=f"{trait_name}_"
+                    )
+                except AttributeError:
+                    print(f"Issue computing summary for: {plant.series_name}/{trait_name} ({plant_traits[trait_name]})")
+                    raise
                 plant_summary.update(trait_summary)
             all_traits.append(plant_summary)
 
@@ -714,7 +718,7 @@ class DicotPipeline(Pipeline):
                 input_traits=["primary_tip_pt"],
                 scalar=True,
                 include_in_csv=True,
-                kwargs={},
+                kwargs={"flatten": True},
                 description="Y-coordinate of the primary root tip node.",
             ),
             TraitDef(

--- a/sleap_roots/trait_pipelines.py
+++ b/sleap_roots/trait_pipelines.py
@@ -636,9 +636,8 @@ class DicotPipeline(Pipeline):
                 input_traits=["lateral_base_pts"],
                 scalar=False,
                 include_in_csv=True,
-                kwargs={"monocots": False},
-                description="Array of the x-coordinates of lateral bases "
-                "`(instances,)`.",
+                kwargs={},
+                description="Get x coordinates of the base of each lateral root.",
             ),
             TraitDef(
                 name="lateral_base_ys",

--- a/sleap_roots/trait_pipelines.py
+++ b/sleap_roots/trait_pipelines.py
@@ -655,7 +655,7 @@ class DicotPipeline(Pipeline):
                 input_traits=["primary_length", "lateral_base_pts"],
                 scalar=True,
                 include_in_csv=True,
-                kwargs={"monocots": False},
+                kwargs={},
                 description="Scalar of base count density.",
             ),
             TraitDef(

--- a/tests/test_bases.py
+++ b/tests/test_bases.py
@@ -383,8 +383,10 @@ def test_get_base_ct_density_rice(rice_h5):
     )
     primary, lateral = series[0]
     primary_pts = primary.numpy()
+    primary_max_length = get_root_lengths_max(primary_pts)
     lateral_pts = lateral.numpy()
-    base_ct_density = get_base_ct_density(primary_pts, lateral_pts, monocots)
+    bases = get_bases(lateral_pts, monocots=monocots)
+    base_ct_density = get_base_ct_density(primary_max_length, bases)
     assert np.isnan(base_ct_density)
 
 

--- a/tests/test_bases.py
+++ b/tests/test_bases.py
@@ -234,7 +234,8 @@ def test_get_base_xs_canola(canola_h5):
     )
     lateral = plant[0][1]  # first frame, lateral labels
     lateral_pts = lateral.numpy()  # lateral points as numpy array
-    base_xs = get_base_xs(lateral_pts, monocots)
+    bases = get_bases(lateral_pts)
+    base_xs = get_base_xs(bases)
     assert base_xs.shape[0] == 5
     np.testing.assert_almost_equal(base_xs[1], 1112.5506591796875, decimal=3)
 
@@ -247,13 +248,15 @@ def test_get_base_xs_rice(rice_h5):
     )
     lateral = plant[0][1]  # first frame, lateral labels
     lateral_pts = lateral.numpy()  # lateral points as numpy array
-    base_xs = get_base_xs(lateral_pts, monocots)
+    bases = get_bases(lateral_pts, monocots=monocots)
+    base_xs = get_base_xs(bases)
     assert np.isnan(base_xs)
 
 
 # test get_base_xs with pts_standard
 def test_get_base_xs_standard(pts_standard):
-    base_xs = get_base_xs(pts_standard)
+    bases = get_bases(pts_standard)
+    base_xs = get_base_xs(bases)
     assert base_xs.shape[0] == 2
     np.testing.assert_almost_equal(base_xs[0], 1, decimal=3)
     np.testing.assert_almost_equal(base_xs[1], 5, decimal=3)
@@ -261,7 +264,8 @@ def test_get_base_xs_standard(pts_standard):
 
 # test get_base_xs with pts_no_roots
 def test_get_base_xs_no_roots(pts_no_roots):
-    base_xs = get_base_xs(pts_no_roots)
+    bases = get_bases(pts_no_roots)
+    base_xs = get_base_xs(bases)
     assert base_xs.shape[0] == 2
     np.testing.assert_almost_equal(base_xs[0], np.nan, decimal=3)
 

--- a/tests/test_tips.py
+++ b/tests/test_tips.py
@@ -113,6 +113,7 @@ def test_get_tip_xs_no_tip(pts_no_tips):
     tip_xs = get_tip_xs(tips[[0]], flatten=True)
     assert type(tip_xs) == np.float64
 
+
 # test get_tip_ys with canola
 def test_get_tip_ys_canola(canola_h5):
     series = Series.load(

--- a/tests/test_tips.py
+++ b/tests/test_tips.py
@@ -87,14 +87,16 @@ def test_get_tip_xs_canola(canola_h5):
     )
     lateral = series[0][1]  # LabeledFrame
     lateral_pts = lateral.numpy()  # Lateral roots as a numpy array
-    tip_xs = get_tip_xs(lateral_pts)
+    tips = get_tips(lateral_pts)
+    tip_xs = get_tip_xs(tips)
     assert tip_xs.shape[0] == 5
     np.testing.assert_almost_equal(tip_xs[1], 1072.6610107421875, decimal=3)
 
 
 # test get_tip_xs with standard points
 def test_get_tip_xs_standard(pts_standard):
-    tip_xs = get_tip_xs(pts_standard)
+    tips = get_tips(pts_standard)
+    tip_xs = get_tip_xs(tips)
     assert tip_xs.shape[0] == 2
     np.testing.assert_almost_equal(tip_xs[0], 3, decimal=3)
     np.testing.assert_almost_equal(tip_xs[1], 7, decimal=3)
@@ -102,7 +104,8 @@ def test_get_tip_xs_standard(pts_standard):
 
 # test get_tip_xs with no tips
 def test_get_tip_xs_no_tip(pts_no_tips):
-    tip_xs = get_tip_xs(pts_no_tips)
+    tips = get_tips(pts_no_tips)
+    tip_xs = get_tip_xs(tips)
     assert tip_xs.shape[0] == 2
     np.testing.assert_almost_equal(tip_xs[1], np.nan, decimal=3)
 

--- a/tests/test_tips.py
+++ b/tests/test_tips.py
@@ -108,7 +108,10 @@ def test_get_tip_xs_no_tip(pts_no_tips):
     tip_xs = get_tip_xs(tips)
     assert tip_xs.shape[0] == 2
     np.testing.assert_almost_equal(tip_xs[1], np.nan, decimal=3)
+    assert type(tip_xs) == np.ndarray
 
+    tip_xs = get_tip_xs(tips[[0]], flatten=True)
+    assert type(tip_xs) == np.float64
 
 # test get_tip_ys with canola
 def test_get_tip_ys_canola(canola_h5):
@@ -138,3 +141,7 @@ def test_get_tip_ys_no_tip(pts_no_tips):
     tip_ys = get_tip_ys(tips)
     assert tip_ys.shape[0] == 2
     np.testing.assert_almost_equal(tip_ys[1], np.nan, decimal=3)
+    assert type(tip_ys) == np.ndarray
+
+    tip_ys = get_tip_ys(tips[[0]], flatten=True)
+    assert type(tip_ys) == np.float64


### PR DESCRIPTION
This PR:

- simplifies the base and tip x and y functions to expect inputs from the `get_bases` and `get_tips` functions
- modifies the outputs of tip x and y functions to output a scalar when a single tip is found