### PR TITLE
Add Python 3.7 as compatible version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,12 +2,9 @@
 name: Build
 
 on:
-  push:
-    branches:
-      elizabeth/build_python37
-  # release:
-  #   types:
-  #     - published
+  release:
+    types:
+      - published
 
 jobs:
   pypi:
@@ -21,8 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
-        # python-version: 3.9
+        python-version: 3.9
 
     - name: Install dependencies
       run: |
@@ -33,8 +29,8 @@ jobs:
         python -m build --wheel
         twine check dist/*
     
-    # - name: Upload
-    #   env:
-    #     PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-    #   run: |
-    #     twine upload -u __token__ -p "$PYPI_TOKEN" dist/* --non-interactive --skip-existing --disable-progress-bar
+    - name: Upload
+      env:
+        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        twine upload -u __token__ -p "$PYPI_TOKEN" dist/* --non-interactive --skip-existing --disable-progress-bar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,12 @@
 name: Build
 
 on:
-  release:
-    types:
-      - published
+  push:
+    branches:
+      elizabeth/build_python37
+  # release:
+  #   types:
+  #     - published
 
 jobs:
   pypi:
@@ -18,7 +21,8 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.7
+        # python-version: 3.9
 
     - name: Install dependencies
       run: |
@@ -29,8 +33,8 @@ jobs:
         python -m build --wheel
         twine check dist/*
     
-    - name: Upload
-      env:
-        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      run: |
-        twine upload -u __token__ -p "$PYPI_TOKEN" dist/* --non-interactive --skip-existing --disable-progress-bar
+    # - name: Upload
+    #   env:
+    #     PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+    #   run: |
+    #     twine upload -u __token__ -p "$PYPI_TOKEN" dist/* --non-interactive --skip-existing --disable-progress-bar

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,11 @@ authors = [
     {name = "Talmo Pereira", email = "talmo@salk.edu"}
 ]
 description="Analysis tools for SLEAP-based plant root phenotyping."
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 keywords = ["sleap", "plants", "roots", "phenotyping"]
 license = {text = "BSD-3-Clause"}
 classifiers = [
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9"
 ]


### PR DESCRIPTION
This PR adds Python 3.7 to the allowed Python versions for `pip` installing on older environments.