### PR TITLE
Update sleap-io minimum version to be 0.0.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "pandas",
     "matplotlib",
     "seaborn",
-    "sleap-io>=0.0.6",
+    "sleap-io>=0.0.11",
     "scikit-image",
     "shapely"
 ]


### PR DESCRIPTION
Require dependencies to use newer `sleap-io` with a version of at least 0.0.11