### PR TITLE
Update version number to 0.0.4

### DIFF
--- a/sleap_roots/__init__.py
+++ b/sleap_roots/__init__.py
@@ -16,4 +16,4 @@ from sleap_roots.series import Series, find_all_series
 
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release version.
-__version__ = "0.0.2"
+__version__ = "0.0.4"


### PR DESCRIPTION
Correct version number for PyPI release v0.0.4
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
**Chore**: 
- Updated the package version from "0.0.2" to "0.0.4". 

Please note that this release does not include any new features, bug fixes, or other changes. The version update is purely administrative.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->