### PR TITLE
Add `YoungerMonocotPipeline` to init

### DIFF
--- a/sleap_roots/__init__.py
+++ b/sleap_roots/__init__.py
@@ -11,7 +11,7 @@ import sleap_roots.scanline
 import sleap_roots.series
 import sleap_roots.summary
 import sleap_roots.trait_pipelines
-from sleap_roots.trait_pipelines import DicotPipeline, TraitDef
+from sleap_roots.trait_pipelines import DicotPipeline, TraitDef, YoungerMonocotPipeline
 from sleap_roots.series import Series, find_all_series
 
 # Define package version.


### PR DESCRIPTION
- Added `YoungerMonocotPipeline` to `__init__` so that it can be called as `sleap_roots.YoungerMonocotPipeline` for accessibility. 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added the `YoungerMonocotPipeline` class to the main Sleap Roots module. This update provides users with direct access to this pipeline, enhancing the functionality and usability of the Sleap Roots package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->