### PR TITLE
Fix `get_network_distribution`

### DIFF
--- a/sleap_roots/networklength.py
+++ b/sleap_roots/networklength.py
@@ -2,8 +2,8 @@
 
 import numpy as np
 from shapely import LineString, Polygon
-from sleap_roots.lengths import get_root_lengths, get_max_length_pts
-from typing import Optional, Tuple, Union
+from sleap_roots.lengths import get_max_length_pts
+from typing import Tuple, Union
 
 
 def get_bbox(pts: np.ndarray) -> Tuple[float, float, float, float]:
@@ -198,10 +198,11 @@ def get_network_distribution(
     # Calculate length of roots within the lower bounding box
     network_length = 0
     for root in all_roots:
-        root_poly = LineString(root)
-        lower_intersection = root_poly.intersection(lower_box)
-        root_length = lower_intersection.length
-        network_length += root_length if ~np.isnan(root_length) else 0
+        if len(root) > 1:  # Ensure that root has more than one point
+            root_poly = LineString(root)
+            lower_intersection = root_poly.intersection(lower_box)
+            root_length = lower_intersection.length
+            network_length += root_length if ~np.isnan(root_length) else 0
 
     return network_length
 


### PR DESCRIPTION
- Add check to `get_network_distribution` for roots with less than one point
- Add tests for `get_network_distribution`
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Updated `get_network_distribution` function in `sleap_roots/networklength.py` to handle roots with only one point, ensuring accurate network length calculations.
- Test: Added comprehensive test cases for `get_network_distribution` in `tests/test_networklength.py`, covering scenarios including single-point networks, empty arrays, NaN values, and various fraction values. This enhances the robustness of our testing suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->