### PR TITLE
Exclude jupyter notebooks from language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 *.h5 filter=lfs diff=lfs merge=lfs -text
 *.slp filter=lfs diff=lfs merge=lfs -text
 *.type filter=lfs diff=lfs merge=lfs -text
+
+# Exclude jupyter notebooks from language statistics
+*.ipynb linguist-detectable=false


### PR DESCRIPTION
- Modified git attributes to exclude the jupyter notebooks from the language count on github

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Excluded Jupyter notebooks from language statistics to improve accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->