### PR TITLE
Fix tips and add jupyter lab to the environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           pytest --cov=sleap_roots --cov-report=xml tests/
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python == 3.9 }}
         with:
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,5 +106,6 @@ jobs:
         uses: codecov/codecov-action@v4
         if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python == 3.9 }}
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: false

--- a/README.md
+++ b/README.md
@@ -139,19 +139,16 @@ convex_hull = sr.convhull.get_convhull(pts)
 Jupyter notebooks are located in this repo at `sleap-roots/notebooks`.
 
 To use them, activate your conda environment which includes JupyterLab (recommended):
-
 ```
 conda activate sleap-roots
 ```
 
 Clone this repository if you haven't already:
-
 ```
 git clone https://github.com/talmolab/sleap-roots.git && cd sleap-roots
 ```
 
 Then you can change directories to the location of the notebooks, and open Jupyter Lab:
-
 ```
 cd notebooks
 jupyter lab

--- a/sleap_roots/__init__.py
+++ b/sleap_roots/__init__.py
@@ -23,4 +23,4 @@ from sleap_roots.series import Series, find_all_series
 
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release version.
-__version__ = "0.0.7"
+__version__ = "0.0.8"

--- a/sleap_roots/tips.py
+++ b/sleap_roots/tips.py
@@ -76,4 +76,3 @@ def get_tip_ys(tip_pts: np.ndarray) -> np.ndarray:
         return tip_ys[0]
 
     return tip_ys
-

--- a/tests/test_tips.py
+++ b/tests/test_tips.py
@@ -146,11 +146,16 @@ def test_get_tip_ys_standard(pts_standard):
 
 # test get_tip_ys with no tips
 def test_get_tip_ys_no_tip(pts_no_tips):
+    # `pts_no_tips` is a 2x2x2 array with the second point in each frame being `np.nan`
+    # Get the tips from the no tips points
+    # `tips` should be [[np.nan, np.nan], [np.nan, np.nan]]
     tips = get_tips(pts_no_tips)
+    assert tips.shape == (2, 2)
+    np.testing.assert_array_equal(tips, [[np.nan, np.nan], [np.nan, np.nan]])
+    # Get the tip y-coordinates
+    # `tip_ys` should be [np.nan, np.nan]
     tip_ys = get_tip_ys(tips)
     assert tip_ys.shape[0] == 2
     np.testing.assert_almost_equal(tip_ys[1], np.nan, decimal=3)
-    assert type(tip_ys) == np.ndarray
-
-    tip_ys = get_tip_ys(tips[[0]])
+    np.testing.assert_almost_equal(tip_ys[0], np.nan, decimal=3)
     assert type(tip_ys) == np.ndarray


### PR DESCRIPTION
- Black formatting is used throughout
- Fix tests for tips

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Simplified control flow in the tip handling feature by removing an unnecessary return statement.
- **Tests**
	- Added comments for clarity, asserted the shape and content of `tips`, verified the y-coordinates of the tips, and updated the test case to reflect changes in tip calculation logic in the `test_get_tip_ys_no_tip` function.
- **Chores**
	- Updated the version of the `codecov/codecov-action` from `v3` to `v4` in the CI workflow for uploading coverage reports.
- **Chores**
	- Updated the package version from "0.0.7" to "0.0.8" in the `sleap_roots/__init__.py` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->