### PR TITLE
`Series` class accepts .slp files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip install sleap-roots
 
 If you are using conda (recommended):
 ```
-conda create -n sleap-roots python=3.9
+conda create -n sleap-roots python=3.11
 conda activate sleap-roots
 pip install sleap-roots
 ```

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - defaults
 
 dependencies:
-  - python=3.9
+  - python=3.11
   - numpy
   - matplotlib
   - seaborn

--- a/notebooks/Series.ipynb
+++ b/notebooks/Series.ipynb
@@ -1,0 +1,191 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "import json\n",
+    "import os\n",
+    "import seaborn as sns\n",
+    "\n",
+    "# Import the sleap_roots package\n",
+    "import sleap_roots as sr\n",
+    "\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from sleap_roots import Series, find_all_h5_series, find_all_slp_series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.0.9\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Print sleap_roots version\n",
+    "print(sr.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Current directory: d:\\elizabeths_repos\\sleap-roots\\notebooks\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get the current working directory\n",
+    "current_directory = os.getcwd()\n",
+    "\n",
+    "# Print the current working directory\n",
+    "print(\"Current directory:\", current_directory)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Updated current directory: D:\\elizabeths_repos\\sleap-roots\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Use this cell if you want to change the current working directory\n",
+    "\n",
+    "# Define the directory you want to change to\n",
+    "new_directory = \"D:/elizabeths_repos/sleap-roots\"\n",
+    "\n",
+    "# Change the current working directory\n",
+    "os.chdir(new_directory)\n",
+    "\n",
+    "# Get the updated current working directory\n",
+    "updated_directory = os.getcwd()\n",
+    "\n",
+    "# Print the updated current working directory\n",
+    "print(\"Updated current directory:\", updated_directory)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "folder_path = \"tests/data/canola_7do\" # Location of h5 files and predictions\n",
+    "primary_name = \"primary.predictions\" # For loading primary root predictions\n",
+    "lateral_name = \"lateral.predictions\" # For loading lateral root predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['tests/data/canola_7do/919QDUH.h5']"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Find all h5 files in the folder\n",
+    "all_h5s = sr.find_all_h5_series(folder_path)\n",
+    "all_h5s"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Primary prediction file not found: 919QDUH.primary.predictions.slp\n",
+      "Error loading prediction files: 'str' object has no attribute 'as_posix'\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[Series(series_name='919QDUH', h5_path='tests/data/canola_7do/919QDUH.h5', primary_labels=None, lateral_labels=None, crown_labels=None, video=None, csv_path=None)]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Load the cylinder series (one per h5 file)\n",
+    "all_series = [sr.Series.load(h5_path=h5, primary_name=primary_name, lateral_name=lateral_name) for h5 in all_h5s]\n",
+    "all_series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "sleap-roots-dev",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/Series.ipynb
+++ b/notebooks/Series.ipynb
@@ -132,7 +132,7 @@
      "output_type": "stream",
      "text": [
       "Primary prediction file not found: 919QDUH.primary.predictions.slp\n",
-      "Error loading prediction files: 'str' object has no attribute 'as_posix'\n"
+      "Lateral prediction file not found: 919QDUH.lateral.predictions.slp\n"
      ]
     },
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pandas",
     "matplotlib",
     "seaborn",
-    "sleap-io>=0.1.0",
+    "sleap-io>=0.0.11",
     "scikit-image",
     "shapely"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,9 @@ license = {text = "BSD-3-Clause"}
 classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9"
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11"
 ]
 dependencies = [
     "numpy",
@@ -25,7 +27,7 @@ dependencies = [
     "pandas",
     "matplotlib",
     "seaborn",
-    "sleap-io>=0.0.11",
+    "sleap-io>=0.1.0",
     "scikit-image",
     "shapely"
 ]

--- a/sleap_roots/__init__.py
+++ b/sleap_roots/__init__.py
@@ -19,7 +19,7 @@ from sleap_roots.trait_pipelines import (
     OlderMonocotPipeline,
     MultipleDicotPipeline,
 )
-from sleap_roots.series import Series, find_all_series
+from sleap_roots.series import Series, find_all_h5_series, find_all_slp_series
 
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release version.

--- a/sleap_roots/series.py
+++ b/sleap_roots/series.py
@@ -67,7 +67,7 @@ class Series:
                 expected to be named "{series_name}.{prediction_name}.slp".
             h5_path: Path to the HDF5-formatted image series. If the video in any of the
                 labels is not found, the path will be used to replace the filename. This
-                is necessary for plotting (if the video in the labels is not found).
+                is necessary for plotting.
             primary_name: Optional path to primary prediction file ending with .slp. If
                 a string is provided that does not end with .slp, the string is assumed
                 to be the ending of predictions filewith the format
@@ -135,8 +135,9 @@ class Series:
         # Replace the filename in the labels with the h5_path if it is provided.
         if h5_path is not None:
             for labels in [primary_labels, lateral_labels, crown_labels]:
-                if not labels.video.exists():
-                    labels.video.replace_filename(h5_path)
+                if labels is not None:
+                    if not labels.video.exists():
+                        labels.video.replace_filename(h5_path)
 
         # Attempt to load the video, with error handling
         video = None

--- a/sleap_roots/series.py
+++ b/sleap_roots/series.py
@@ -366,7 +366,7 @@ class Series:
         return crown_pts
 
 
-def find_all_series(data_folders: Union[str, List[str]]) -> List[str]:
+def find_all_h5_series(data_folders: Union[str, List[str]]) -> List[str]:
     """Find all .h5 series from a list of folders.
 
     Args:
@@ -382,6 +382,10 @@ def find_all_series(data_folders: Union[str, List[str]]) -> List[str]:
     for data_folder in data_folders:
         h5_series.extend([Path(p).as_posix() for p in Path(data_folder).glob("*.h5")])
     return h5_series
+
+
+def find_all_slp_series(data_folders: Union[str, List[str]]) -> List[str]:
+    """Find all .slp series from a list of folders."""
 
 
 def imgfig(

--- a/sleap_roots/series.py
+++ b/sleap_roots/series.py
@@ -98,7 +98,7 @@ class Series:
         try:
             if primary_name:
                 if Path(primary_name).as_posix().endswith(".slp"):
-                    primary_path = primary_name
+                    primary_path = Path(primary_name).as_posix()
                 else:
                     primary_path = (
                         Path(series_name).with_suffix(f".{primary_name}.slp").as_posix()
@@ -108,8 +108,8 @@ class Series:
                 else:
                     print(f"Primary prediction file not found: {primary_path}")
             if lateral_name:
-                if lateral_name.endswith(".slp"):
-                    lateral_path = lateral_name
+                if Path(lateral_name).as_posix().endswith(".slp"):
+                    lateral_path = Path(lateral_name).as_posix()
                 else:
                     lateral_path = (
                         Path(series_name).with_suffix(f".{lateral_name}.slp").as_posix()
@@ -119,8 +119,8 @@ class Series:
                 else:
                     print(f"Lateral prediction file not found: {lateral_path}")
             if crown_name:
-                if crown_name.endswith(".slp"):
-                    crown_path = crown_name
+                if Path(crown_name).as_posix().endswith(".slp"):
+                    crown_path = Path(crown_name).as_posix()
                 else:
                     crown_path = (
                         Path(series_name).with_suffix(f".{crown_name}.slp").as_posix()
@@ -203,7 +203,7 @@ class Series:
 
     def __len__(self) -> int:
         """Length of the series (number of images)."""
-        return len(self.video)
+        return len(self)
 
     def __getitem__(self, idx: int) -> Dict[str, Optional[sio.LabeledFrame]]:
         """Return labeled frames for primary and/or lateral and/or crown predictions."""

--- a/sleap_roots/series.py
+++ b/sleap_roots/series.py
@@ -97,25 +97,34 @@ class Series:
         # Attempt to load the predictions, with error handling
         try:
             if primary_name:
-                primary_path = (
-                    Path(series_name).with_suffix(f".{primary_name}.slp").as_posix()
-                )
+                if Path(primary_name).as_posix().endswith(".slp"):
+                    primary_path = primary_name
+                else:
+                    primary_path = (
+                        Path(series_name).with_suffix(f".{primary_name}.slp").as_posix()
+                    )
                 if Path(primary_path).exists():
                     primary_labels = sio.load_slp(primary_path)
                 else:
                     print(f"Primary prediction file not found: {primary_path}")
             if lateral_name:
-                lateral_path = (
-                    Path(series_name).with_suffix(f".{lateral_name}.slp").as_posix()
-                )
+                if lateral_name.endswith(".slp"):
+                    lateral_path = lateral_name
+                else:
+                    lateral_path = (
+                        Path(series_name).with_suffix(f".{lateral_name}.slp").as_posix()
+                    )
                 if Path(lateral_path).exists():
                     lateral_labels = sio.load_slp(lateral_path)
                 else:
                     print(f"Lateral prediction file not found: {lateral_path}")
             if crown_name:
-                crown_path = (
-                    Path(series_name).with_suffix(f".{crown_name}.slp").as_posix()
-                )
+                if crown_name.endswith(".slp"):
+                    crown_path = crown_name
+                else:
+                    crown_path = (
+                        Path(series_name).with_suffix(f".{crown_name}.slp").as_posix()
+                    )
                 if Path(crown_path).exists():
                     crown_labels = sio.load_slp(crown_path)
                 else:
@@ -385,7 +394,21 @@ def find_all_h5_series(data_folders: Union[str, List[str]]) -> List[str]:
 
 
 def find_all_slp_series(data_folders: Union[str, List[str]]) -> List[str]:
-    """Find all .slp series from a list of folders."""
+    """Find all .slp series from a list of folders.
+
+    Args:
+        data_folders: Path or list of paths to folders containing .slp series.
+
+    Returns:
+        A list of unique series names derived from the filenames.
+    """
+    if type(data_folders) != list:
+        data_folders = [data_folders]
+
+    slp_series = []
+    for data_folder in data_folders:
+        slp_series.extend([Path(p).as_posix() for p in Path(data_folder).glob("*.slp")])
+    return list(set([Path(p).name.split(".")[0] for p in slp_series]))
 
 
 def imgfig(

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -9,7 +9,7 @@ from typing import Literal
 @pytest.fixture
 def series_instance():
     # Create a Series instance with dummy data
-    return Series(h5_path="dummy.h5")
+    return Series(series_name="dummy", video=["frame1", "frame2"])
 
 
 @pytest.fixture
@@ -71,11 +71,6 @@ def test_get_frame(dummy_series):
     assert "crown" in frames
 
 
-def test_series_name_property():
-    series = Series(h5_path="mock_path/file_name.h5")
-    assert series.series_name == "file_name"
-
-
 def test_series_name(series_instance):
     assert series_instance.series_name == "dummy"
 
@@ -90,13 +85,12 @@ def test_qc_cylinder(series_instance, csv_path):
     assert series_instance.qc_fail == 0
 
 
-def test_len():
-    series = Series(video=["frame1", "frame2"])
-    assert len(series) == 2
-
-
 def test_series_load_canola(canola_h5: Literal["tests/data/canola_7do/919QDUH.h5"]):
-    series = Series.load(canola_h5, primary_name="primary", lateral_name="lateral")
+    series = Series.load(
+        h5_path=canola_h5,
+        primary_name="primary.predictions",
+        lateral_name="lateral.predictions",
+    )
     assert len(series) == 72
 
 

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1,7 +1,7 @@
 import sleap_io as sio
 import numpy as np
 import pytest
-from sleap_roots.series import Series, find_all_series
+from sleap_roots.series import Series, find_all_h5_series, find_all_slp_series
 from pathlib import Path
 from typing import Literal
 
@@ -14,7 +14,7 @@ def series_instance():
 
 @pytest.fixture
 def dummy_video_path(tmp_path):
-    video_path = tmp_path / "dummy_video.mp4"
+    video_path = tmp_path / "dummy_video.h5"
     video_path.write_text("This is a dummy video file.")
     return str(video_path)
 
@@ -100,8 +100,8 @@ def test_series_load_canola(canola_h5: Literal["tests/data/canola_7do/919QDUH.h5
     assert len(series) == 72
 
 
-def test_find_all_series_canola(canola_folder: Literal["tests/data/canola_7do"]):
-    all_series_files = find_all_series(canola_folder)
+def test_find_all_h5_series_canola(canola_folder: Literal["tests/data/canola_7do"]):
+    all_series_files = find_all_h5_series(canola_folder)
     assert len(all_series_files) == 1
 
 
@@ -139,13 +139,15 @@ def test_get_frame_rice_10do(
     assert series.series_name == "0K9E8BI"
 
 
-def test_find_all_series_rice_10do(rice_10do_folder: Literal["tests/data/rice_10do"]):
+def test_find_all_h5_series_rice_10do(
+    rice_10do_folder: Literal["tests/data/rice_10do"],
+):
     series_h5_path = Path(rice_10do_folder) / "0K9E8BI.h5"
-    all_series_files = find_all_series(rice_10do_folder)
+    all_series_files = find_all_h5_series(rice_10do_folder)
     assert len(all_series_files) == 1
     assert series_h5_path.as_posix() == "tests/data/rice_10do/0K9E8BI.h5"
 
 
-def test_find_all_series_rice(rice_folder: Literal["tests/data/rice_3do"]):
-    all_series_files = find_all_series(rice_folder)
+def test_find_all_h5_series_rice(rice_folder: Literal["tests/data/rice_3do"]):
+    all_series_files = find_all_h5_series(rice_folder)
     assert len(all_series_files) == 2

--- a/tests/test_trait_pipelines.py
+++ b/tests/test_trait_pipelines.py
@@ -6,13 +6,19 @@ from sleap_roots.trait_pipelines import (
     OlderMonocotPipeline,
     MultipleDicotPipeline,
 )
-from sleap_roots.series import Series, find_all_series
+from sleap_roots.series import Series, find_all_h5_series, find_all_slp_series
 
 
 def test_dicot_pipeline(canola_h5, soy_h5):
     # Load the data
-    canola = Series.load(canola_h5, primary_name="primary", lateral_name="lateral")
-    soy = Series.load(soy_h5, primary_name="primary", lateral_name="lateral")
+    canola = Series.load(
+        h5_path=canola_h5,
+        primary_name="primary.predictions",
+        lateral_name="lateral.predictions",
+    )
+    soy = Series.load(
+        soy_h5, primary_name="primary.predictions", lateral_name="lateral.predictions"
+    )
 
     pipeline = DicotPipeline()
     canola_traits = pipeline.compute_plant_traits(canola)
@@ -25,7 +31,7 @@ def test_dicot_pipeline(canola_h5, soy_h5):
 
 
 def test_OlderMonocot_pipeline(rice_main_10do_h5):
-    rice = Series.load(rice_main_10do_h5, crown_name="crown")
+    rice = Series.load(h5_path=rice_main_10do_h5, crown_name="crown.predictions")
 
     pipeline = OlderMonocotPipeline()
     rice_10dag_traits = pipeline.compute_plant_traits(rice)
@@ -34,10 +40,16 @@ def test_OlderMonocot_pipeline(rice_main_10do_h5):
 
 
 def test_younger_monocot_pipeline(rice_h5, rice_folder):
-    rice = Series.load(rice_h5, primary_name="primary", crown_name="crown")
-    rice_series_all = find_all_series(rice_folder)
+    rice = Series.load(
+        h5_path=rice_h5,
+        primary_name="primary.predictions",
+        crown_name="crown.predictions",
+    )
+    rice_series_all = find_all_h5_series(rice_folder)
     series_all = [
-        Series.load(series, primary_name="primary", crown_name="crown")
+        Series.load(
+            series, primary_name="primary.predictions", crown_name="crown.predictions"
+        )
         for series in rice_series_all
     ]
 
@@ -91,9 +103,12 @@ def test_younger_monocot_pipeline(rice_h5, rice_folder):
 
 
 def test_older_monocot_pipeline(rice_main_10do_h5, rice_10do_folder):
-    rice = Series.load(rice_main_10do_h5, crown_name="crown")
-    rice_series_all = find_all_series(rice_10do_folder)
-    series_all = [Series.load(series, crown_name="crown") for series in rice_series_all]
+    rice = Series.load(h5_path=rice_main_10do_h5, crown_name="crown.predictions")
+    rice_series_all = find_all_h5_series(rice_10do_folder)
+    series_all = [
+        Series.load(series, crown_name="crown.predictions")
+        for series in rice_series_all
+    ]
 
     pipeline = OlderMonocotPipeline()
     rice_traits = pipeline.compute_plant_traits(rice)
@@ -144,17 +159,17 @@ def test_multiple_dicot_pipeline(
     multiple_arabidopsis_11do_csv,
 ):
     arabidopsis = Series.load(
-        multiple_arabidopsis_11do_h5,
-        primary_name="primary",
-        lateral_name="lateral",
+        h5_path=multiple_arabidopsis_11do_h5,
+        primary_name="primary.predictions",
+        lateral_name="lateral.predictions",
         csv_path=multiple_arabidopsis_11do_csv,
     )
-    arabidopsis_series_all = find_all_series(multiple_arabidopsis_11do_folder)
+    arabidopsis_series_all = find_all_h5_series(multiple_arabidopsis_11do_folder)
     series_all = [
         Series.load(
-            series,
-            primary_name="primary",
-            lateral_name="lateral",
+            h5_path=series,
+            primary_name="primary.predictions",
+            lateral_name="lateral.predictions",
             csv_path=multiple_arabidopsis_11do_csv,
         )
         for series in arabidopsis_series_all

--- a/tests/test_trait_pipelines.py
+++ b/tests/test_trait_pipelines.py
@@ -17,7 +17,9 @@ def test_dicot_pipeline(canola_h5, soy_h5):
         lateral_name="lateral.predictions",
     )
     soy = Series.load(
-        soy_h5, primary_name="primary.predictions", lateral_name="lateral.predictions"
+        h5_path=soy_h5,
+        primary_name="primary.predictions",
+        lateral_name="lateral.predictions",
     )
 
     pipeline = DicotPipeline()


### PR DESCRIPTION
- h5 paths are optional in the `Series` class but necessary for the plotting function
- `series_name` is now an attribute that uniquely identifies the sample
- `series_name` can be found using the `h5_path` or directly input
- `find_all_slp_series` added to find unique `series_name` from .slp files in a list of data folders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the `Series` class with a new attribute for series naming and improved parameter handling in the loading method.
  - Introduced a new notebook `Series.ipynb` for managing series data using the `sleap_roots` package.

- **Enhancements**
  - Updated support for Python versions 3.10 and 3.11 in the project configuration.

- **Refactor**
  - Renamed function to better reflect its functionality from `find_all_h5_series` to `find_all_slp_series`.

- **Documentation**
  - Updated README to reflect new Python version setup instructions.

- **Bug Fixes**
  - Adjusted function calls in test files to align with updated method signatures and enhanced functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->