### PR TITLE
Upgrade python to 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
 
     - name: Install dependencies
       run: |
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-22.04", "windows-2022"]
-        python: [3.9]
+        python: [3.11]
 
     name: Tests (${{ matrix.os }}, Python ${{ matrix.python }})
     runs-on: ${{ matrix.os }}
@@ -91,20 +91,20 @@ jobs:
           pip freeze
 
       - name: Test with pytest
-        if: ${{ !(startsWith(matrix.os, 'ubuntu') && matrix.python == 3.9) }}
+        if: ${{ !(startsWith(matrix.os, 'ubuntu') && matrix.python == 3.11) }}
         shell: bash -l {0}
         run: |
           pytest
 
       - name: Test with pytest (with coverage)
-        if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python == 3.9 }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python == 3.11 }}
         shell: bash -l {0}
         run: |
           pytest --cov=sleap_roots --cov-report=xml tests/
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4
-        if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python == 3.9 }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python == 3.11 }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip install sleap-roots
 
 If you are using conda (recommended):
 ```
-conda create -n sleap-roots python=3.9
+conda create -n sleap-roots python=3.11
 conda activate sleap-roots
 pip install sleap-roots
 ```

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - defaults
 
 dependencies:
-  - python=3.9
+  - python=3.11
   - numpy
   - matplotlib
   - seaborn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,9 @@ license = {text = "BSD-3-Clause"}
 classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9"
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11"
 ]
 dependencies = [
     "numpy",

--- a/sleap_roots/__init__.py
+++ b/sleap_roots/__init__.py
@@ -29,4 +29,4 @@ from sleap_roots.series import (
 
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release version.
-__version__ = "0.0.9"
+__version__ = "0.1.0"


### PR DESCRIPTION
- change python in environment to 3.11
-  update pip package document use of python 3.10 and 3.11
-  add python 3.11 to suggestion in README
-  bump version number

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the software to support Python versions 3.10 and 3.11.
  - Upgraded the package version to 0.1.0.

- **Documentation**
  - Revised installation instructions to use Python 3.11.

- **Chores**
  - Updated Python version dependency in the project environment setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->