### PR TITLE
Add Return Value to Series.plot

### DIFF
--- a/sleap_roots/series.py
+++ b/sleap_roots/series.py
@@ -316,11 +316,10 @@ class Series:
                 # Plot the instances
                 plot_instances(labeled_frame.instances, cmap=[color], **kwargs)
 
-        # Get the current figure and assign it to a variable.
+        # Capture the current plot after calling plot_img and plot_instances.
         fig = plt.gcf()
 
-        # plot_img and plot_instances do not return matplotlib.Figure objects but a plot is rendered in cells.
-        # Close all current open plots to avoid duplication.
+        # Close all current open plots to avoid duplicate rending from Jupyter.
         plt.close("all")
 
         # Jupyter automatically renders plots when Figure objects are returned from functions.

--- a/sleap_roots/series.py
+++ b/sleap_roots/series.py
@@ -311,6 +311,14 @@ class Series:
                 # Plot the instances
                 plot_instances(labeled_frame.instances, cmap=[color], **kwargs)
 
+        # Get the current figure and display it
+        fig = plt.gcf()
+
+        # Close one window to prevent plot from displaying twice
+        plt.close(1)
+
+        return fig
+
     def get_primary_points(self, frame_idx: int) -> np.ndarray:
         """Get primary root points.
 

--- a/sleap_roots/series.py
+++ b/sleap_roots/series.py
@@ -319,10 +319,10 @@ class Series:
         # Capture the current plot after calling plot_img and plot_instances.
         fig = plt.gcf()
 
-        # Close all current open plots to avoid duplicate rending from Jupyter.
-        plt.close("all")
+        # Close the captured fig to avoid duplicate rendering from Jupyter.
+        plt.close(fig)
 
-        # Jupyter automatically renders plots when Figure objects are returned from functions.
+        # Return the figure. In a cell, Jupyter will automatically render the plot.
         return fig
 
     def get_primary_points(self, frame_idx: int) -> np.ndarray:

--- a/sleap_roots/series.py
+++ b/sleap_roots/series.py
@@ -267,13 +267,18 @@ class Series:
 
         return frames
 
-    def plot(self, frame_idx: int, scale: float = 1.0, **kwargs):
+    def plot(
+        self, frame_idx: int, scale: float = 1.0, **kwargs
+    ) -> matplotlib.figure.Figure:
         """Plot predictions on top of the image.
 
         Args:
             frame_idx: Frame index to visualize.
             scale: Relative size of the visualized image. Useful for plotting smaller
                 images within notebooks.
+
+        Returns:
+            matplotlib.figure.Figure object that shows predictions on top of images.
         """
         # Check if the video is available
         if self.video is None:
@@ -311,12 +316,14 @@ class Series:
                 # Plot the instances
                 plot_instances(labeled_frame.instances, cmap=[color], **kwargs)
 
-        # Get the current figure and display it
+        # Get the current figure and assign it to a variable.
         fig = plt.gcf()
 
-        # Close one window to prevent plot from displaying twice
-        plt.close(1)
+        # plot_img and plot_instances do not return matplotlib.Figure objects but a plot is rendered in cells.
+        # Close all current open plots to avoid duplication.
+        plt.close("all")
 
+        # Jupyter automatically renders plots when Figure objects are returned from functions.
         return fig
 
     def get_primary_points(self, frame_idx: int) -> np.ndarray:

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -426,5 +426,5 @@ def test_series_plot(
 
     for series in series_examples:
         for frame_idx in range(len(series)):
-            plt = series.plot(frame_idx)
-            assert isinstance(plt, matplotlib.figure.Figure)
+            fig = series.plot(frame_idx)
+            assert isinstance(fig, matplotlib.figure.Figure)

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Literal
 from contextlib import redirect_stdout
 import io
+import matplotlib.figure
 
 
 @pytest.fixture
@@ -394,3 +395,36 @@ def test_find_all_series_from_h5s_rice_10do(
     assert len(h5_paths) == 1
     assert len(all_series) == 1
     assert all_series[0].h5_path == series_h5_path.as_posix()
+
+
+def test_series_plot(
+    rice_h5,
+    rice_long_slp,
+    rice_main_slp,
+    canola_h5,
+    canola_primary_slp,
+    canola_lateral_slp,
+):
+    """Test return type of the Series `plot` method."""
+    # Younger Monocot, rice_3do, YR39SJX
+    rice_3do = Series.load(
+        series_name="rice",
+        primary_path=rice_long_slp,
+        crown_path=rice_main_slp,
+        h5_path=rice_h5,
+    )
+
+    # Dicot, canola_7do, 919QDUH
+    canola = rice_3do = Series.load(
+        series_name="canola",
+        primary_path=canola_primary_slp,
+        lateral_path=canola_lateral_slp,
+        h5_path=canola_h5,
+    )
+
+    series_examples = [rice_3do, canola]
+
+    for series in series_examples:
+        for frame_idx in range(len(series)):
+            plt = series.plot(frame_idx)
+            assert isinstance(plt, matplotlib.figure.Figure)


### PR DESCRIPTION
- updated `plot` function in `series.py` to return a matplotlib figure instead of returning NoneType

https://github.com/talmolab/sleap-roots/blob/a858d45155cba7cd07717527dd91b9ffc0f29f72/sleap_roots/series.py#L270


Resolves #101 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced plotting functionality to better manage figure displays. The update now ensures that figures are captured, duplicate displays are prevented, and the plotted output is returned for further use.

- **Tests**
  - Added a new test to validate the return type of the updated plot method, ensuring it returns the expected figure type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->