### PR TITLE
Include macOS in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04", "windows-2022"]
+        os: ["ubuntu-22.04", "windows-2022", "macos-latest"]
         python: [3.11]
 
     name: Tests (${{ matrix.os }}, Python ${{ matrix.python }})


### PR DESCRIPTION
- added macos-latest to the CI matrix, in addition to ubuntu and windows

Fixes #113 