### PR TITLE
Add Fourier shape descriptors for root encoding

### DIFF
--- a/openspec/changes/add-fourier-shape-descriptors/design.md
+++ b/openspec/changes/add-fourier-shape-descriptors/design.md
@@ -1,0 +1,192 @@
+# Design: Fourier Shape Descriptors for Root Skeletons
+
+## Context
+
+sleap-roots extracts root skeleton coordinates as ordered (x, y) point sequences from SLEAP pose estimation. Current trait modules compute interpretable metrics (lengths, angles, hull properties), but researchers also need:
+- Fixed-length embeddings for ML pipelines
+- Shape representations that capture patterns beyond hand-crafted traits
+- Compact encodings for clustering and similarity search
+
+This design describes a lightweight Fourier descriptor module that produces shape embeddings from root polylines using established morphometric techniques.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Produce fixed-length shape embeddings from variable-length root polylines
+- Work with open curves (root skeletons are not closed contours)
+- Zero additional dependencies (NumPy only)
+- Maintain consistency with existing module patterns
+- Support both per-root and aggregated embeddings
+
+**Non-Goals:**
+- Neural network-based encoding (Poly2Vec, Geo2Vec) - requires training
+- 3D shape analysis - roots are 2D projections
+- Real-time processing optimization - batch processing is acceptable
+- Replacing existing interpretable traits - this is complementary
+
+## Decisions
+
+### Decision 1: Tangent Angle Parameterization
+
+**What:** Represent each root as θ(s), the tangent angle as a function of normalized arc length.
+
+**Why:**
+- Standard approach for open biological curves (C. elegans eigenworms)
+- Naturally invariant to translation
+- Rotation invariance achieved by subtracting mean angle
+- Curvature is directly derivable: κ(s) = dθ/ds
+
+**Alternatives considered:**
+- Elliptic Fourier Descriptors: Requires closed contours; would need to artificially close root polylines
+- Raw (x, y) Fourier: Not rotation-invariant without additional normalization
+- Curvature-only: Loses directional information
+
+### Decision 2: Fixed Harmonic Count
+
+**What:** Return first N Fourier coefficients (default N=10, configurable).
+
+**Why:**
+- Low frequencies capture overall shape (straight vs curved)
+- High frequencies capture local variations (wiggles)
+- 10 harmonics is sufficient for ~98% shape reconstruction in similar biological applications
+- Fixed length enables direct use as ML features
+
+**Output format:**
+```python
+# For N harmonics, output is 2N floats:
+# [magnitude_1, ..., magnitude_N, phase_1, ..., phase_N]
+# or alternatively:
+# [real_1, ..., real_N, imag_1, ..., imag_N]
+```
+
+### Decision 3: Arc-Length Resampling
+
+**What:** Resample each root polyline to M uniformly-spaced points along arc length before computing tangent angles.
+
+**Why:**
+- SLEAP predictions have varying node counts and spacing
+- Uniform sampling ensures consistent Fourier analysis
+- Default M=100 provides smooth curves without excessive computation
+
+**Implementation:**
+```python
+def get_arc_length_parameterization(points: np.ndarray, n_samples: int = 100) -> np.ndarray:
+    """Resample polyline to uniform arc-length spacing."""
+    # Compute cumulative arc length
+    # Interpolate to uniform spacing
+    # Return resampled (n_samples, 2) array
+```
+
+### Decision 4: Module-Level Functions (Not Class)
+
+**What:** Implement as standalone functions following existing sleap-roots patterns.
+
+**Why:**
+- Consistent with `lengths.py`, `angle.py`, `tips.py` module structure
+- Functions are stateless and composable
+- Easier to integrate into pipeline `TraitDef` system
+
+### Decision 5: NaN Handling
+
+**What:** Filter NaN nodes before processing; return NaN-filled result for invalid roots.
+
+**Why:**
+- SLEAP predictions may have missing nodes
+- Consistent with existing trait modules' NaN handling
+- Downstream analysis can filter/impute as needed
+
+## API Design
+
+```python
+# sleap_roots/fourier.py
+
+def get_arc_length_parameterization(
+    points: np.ndarray,
+    n_samples: int = 100
+) -> np.ndarray:
+    """Resample polyline to uniform arc-length spacing.
+
+    Args:
+        points: Root skeleton points of shape (n_nodes, 2).
+        n_samples: Number of uniformly-spaced samples to generate.
+
+    Returns:
+        Resampled points of shape (n_samples, 2).
+    """
+
+def get_tangent_angles(
+    points: np.ndarray,
+    normalize: bool = True
+) -> np.ndarray:
+    """Compute tangent angles along a polyline.
+
+    Args:
+        points: Polyline points of shape (n_points, 2).
+        normalize: If True, subtract mean angle for rotation invariance.
+
+    Returns:
+        Tangent angles of shape (n_points - 1,) in radians.
+    """
+
+def get_curvature(points: np.ndarray) -> np.ndarray:
+    """Compute curvature along a polyline.
+
+    Args:
+        points: Polyline points of shape (n_points, 2).
+
+    Returns:
+        Curvature values of shape (n_points - 2,).
+    """
+
+def get_fourier_coefficients(
+    signal: np.ndarray,
+    n_harmonics: int = 10
+) -> np.ndarray:
+    """Compute Fourier coefficients of a 1D signal.
+
+    Args:
+        signal: 1D signal array.
+        n_harmonics: Number of harmonic coefficients to return.
+
+    Returns:
+        Array of shape (2 * n_harmonics,) containing
+        [magnitudes..., phases...] or [real..., imag...].
+    """
+
+def get_fourier_descriptors(
+    points: np.ndarray,
+    n_samples: int = 100,
+    n_harmonics: int = 10,
+    include_curvature: bool = False
+) -> np.ndarray:
+    """Compute Fourier shape descriptors for a root polyline.
+
+    This is the main API for generating fixed-length shape embeddings.
+
+    Args:
+        points: Root skeleton points of shape (n_nodes, 2).
+        n_samples: Arc-length resampling resolution.
+        n_harmonics: Number of Fourier harmonics to compute.
+        include_curvature: If True, append curvature-based descriptors.
+
+    Returns:
+        Shape descriptor array of fixed length.
+    """
+```
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|------------|
+| Fourier descriptors may not outperform existing traits | Position as complementary; validate on real phenotyping tasks |
+| Computational cost for large batches | Profile and optimize; vectorize where possible |
+| Parameter tuning (n_samples, n_harmonics) | Provide sensible defaults; document trade-offs |
+| Interpretability loss vs hand-crafted traits | Document that this is for ML, not direct biological interpretation |
+
+## Open Questions
+
+1. **Output format**: Should coefficients be (magnitude, phase) or (real, imag)? Magnitude/phase may be more interpretable.
+
+2. **Pipeline integration**: Should Fourier descriptors be first-class traits in pipelines, or a separate utility? Initial implementation as standalone functions; pipeline integration can follow if adoption is positive.
+
+3. **Aggregation across roots**: For plants with multiple laterals, how should embeddings be aggregated? Options: per-root, mean pooling, concatenation. Defer to user for now.

--- a/openspec/changes/add-fourier-shape-descriptors/proposal.md
+++ b/openspec/changes/add-fourier-shape-descriptors/proposal.md
@@ -1,0 +1,72 @@
+# Proposal: Add Fourier Shape Descriptors for Root Encoding
+
+## Why
+
+Current trait extraction provides ~40 interpretable morphological traits (lengths, angles, convex hull metrics, etc.), but these are hand-crafted measures that may miss predictive shape patterns not explicitly defined. Researchers need:
+
+1. **ML-ready shape embeddings** for classification, clustering, and prediction tasks where existing traits may leave signal on the table
+2. **Unsupervised phenotype discovery** to find root shape groups that don't map to predefined traits
+3. **Compact shape representations** that capture the "full" morphology in a fixed-length vector
+
+Fourier-based shape descriptors are well-established in biological morphometrics:
+- Elliptic Fourier Descriptors (EFDs) are standard for cell, leaf, and organ shape analysis
+- Tangent angle parameterization is used for worm/nematode pose encoding (C. elegans eigenworms)
+- Curvature Scale Space (CSS) is an MPEG-7 standardized shape descriptor
+
+However, most methods target **closed contours**. Root skeletons are **open polylines**, requiring an adapted approach similar to the tangent angle method used in C. elegans research.
+
+## What Changes
+
+- Add new `sleap_roots/fourier.py` module implementing Fourier shape descriptors for open polylines
+- Implement arc-length parameterized tangent angle representation (proven approach from worm morphology)
+- Compute Fourier coefficients of the tangent angle function to produce fixed-length embeddings
+- Add curvature-based descriptors as complementary features
+- Integrate as optional "traits" in existing pipeline architecture
+- No external dependencies beyond NumPy (already required)
+
+## Impact
+
+**Affected specs:**
+- `trait-computation` (new capability) - Fourier shape descriptor requirements
+
+**Affected code:**
+- `sleap_roots/fourier.py` - New module for Fourier descriptors
+- `sleap_roots/__init__.py` - Export new functions
+- `sleap_roots/trait_pipelines.py` - Optional integration into pipelines
+- `tests/test_fourier.py` - Unit tests for new module
+
+**Non-breaking:** This change adds new optional functionality; existing traits and pipelines are unchanged.
+
+## Research Background
+
+### Tangent Angle Parameterization (Primary Approach)
+
+From C. elegans research (Stephens et al., PLOS Computational Biology):
+- Parameterize curve by arc length `s` (normalized 0 to 1)
+- Compute tangent angle `θ(s)` at each point
+- Apply Fourier transform to `θ(s)` to get coefficients
+- Low-frequency components capture overall shape; high-frequency capture local wiggles
+
+This is ideal for root skeletons because:
+- Works on open curves (not just closed contours)
+- Invariant to position and overall orientation
+- Naturally ordered from base to tip (like head to tail in worms)
+- Curvature `κ(s) = dθ/ds` is directly derivable
+
+### Curvature Scale Space (Complementary)
+
+From MPEG-7 standardization:
+- Compute curvature along the curve
+- Multi-scale analysis captures both global and local shape features
+- Robust to noise and small perturbations
+
+### Why Not EFDs?
+
+Classic Elliptic Fourier Descriptors require closed contours. While we could artificially close root polylines, this introduces artifacts. The tangent angle approach is mathematically cleaner for open curves.
+
+## References
+
+1. Stephens, G.J., et al. "Dimensionality and Dynamics in the Behavior of C. elegans." PLOS Computational Biology, 2008. DOI: 10.1371/journal.pcbi.1000028
+2. Kuhl, F.P. & Giardina, C.R. "Elliptic Fourier features of a closed contour." Computer Graphics and Image Processing, 1982.
+3. Mokhtarian, F. & Mackworth, A.K. "A theory of multiscale, curvature-based shape representation for planar curves." IEEE TPAMI, 1992.
+4. Kriegel, F.L., et al. "Cell shape characterization and classification with discrete Fourier transforms." Cytometry Part A, 2018.

--- a/openspec/changes/add-fourier-shape-descriptors/specs/trait-computation/spec.md
+++ b/openspec/changes/add-fourier-shape-descriptors/specs/trait-computation/spec.md
@@ -1,0 +1,108 @@
+## ADDED Requirements
+
+### Requirement: Fourier Shape Descriptors
+
+The system SHALL provide Fourier-based shape descriptors that encode root polyline morphology into fixed-length vectors suitable for machine learning applications.
+
+The descriptors SHALL be computed using tangent angle parameterization, where the root skeleton is represented as a function θ(s) of normalized arc length s ∈ [0, 1].
+
+The implementation SHALL:
+- Accept root skeleton points as input arrays of shape (n_nodes, 2)
+- Resample polylines to uniform arc-length spacing before analysis
+- Compute Fourier coefficients of the tangent angle function
+- Return fixed-length descriptor arrays regardless of input polyline length
+- Handle missing nodes (NaN values) gracefully by filtering before computation
+- Require no external dependencies beyond NumPy
+
+#### Scenario: Compute Fourier descriptors for a single root
+
+- **GIVEN** a root skeleton with points array of shape (6, 2)
+- **WHEN** `get_fourier_descriptors(points, n_harmonics=10)` is called
+- **THEN** the function returns a 1D array of shape (20,) containing Fourier coefficients
+
+#### Scenario: Handle roots with NaN nodes
+
+- **GIVEN** a root skeleton with some NaN coordinate values
+- **WHEN** `get_fourier_descriptors(points)` is called
+- **THEN** NaN nodes are filtered before computation
+- **AND** valid descriptors are returned if at least 2 non-NaN nodes exist
+
+#### Scenario: Handle degenerate roots
+
+- **GIVEN** a root skeleton with fewer than 2 valid (non-NaN) nodes
+- **WHEN** `get_fourier_descriptors(points)` is called
+- **THEN** the function returns an array filled with NaN values
+
+### Requirement: Arc-Length Parameterization
+
+The system SHALL provide arc-length parameterization to resample polylines to uniform spacing along the curve length.
+
+#### Scenario: Resample polyline to uniform arc length
+
+- **GIVEN** a polyline with non-uniform point spacing
+- **WHEN** `get_arc_length_parameterization(points, n_samples=100)` is called
+- **THEN** the function returns an array of shape (100, 2)
+- **AND** consecutive points are approximately equidistant along the curve
+
+#### Scenario: Preserve polyline endpoints
+
+- **GIVEN** a polyline with defined start and end points
+- **WHEN** `get_arc_length_parameterization(points)` is called
+- **THEN** the first output point matches the original start point
+- **AND** the last output point matches the original end point
+
+### Requirement: Tangent Angle Computation
+
+The system SHALL compute tangent angles along polylines for shape analysis.
+
+The tangent angle θ at each point SHALL represent the direction of the curve relative to the positive x-axis, measured in radians.
+
+#### Scenario: Compute tangent angles for a straight horizontal line
+
+- **GIVEN** a horizontal line from (0, 0) to (10, 0)
+- **WHEN** `get_tangent_angles(points, normalize=False)` is called
+- **THEN** all returned angles are approximately 0
+
+#### Scenario: Compute tangent angles for a straight vertical line
+
+- **GIVEN** a vertical line from (0, 0) to (0, 10)
+- **WHEN** `get_tangent_angles(points, normalize=False)` is called
+- **THEN** all returned angles are approximately π/2
+
+#### Scenario: Rotation-invariant tangent angles
+
+- **GIVEN** any polyline
+- **WHEN** `get_tangent_angles(points, normalize=True)` is called
+- **THEN** the mean of returned angles is approximately 0
+
+### Requirement: Curvature Computation
+
+The system SHALL compute curvature values along polylines as the rate of change of tangent angle with respect to arc length.
+
+#### Scenario: Compute curvature for a straight line
+
+- **GIVEN** a straight line polyline
+- **WHEN** `get_curvature(points)` is called
+- **THEN** all returned curvature values are approximately 0
+
+#### Scenario: Compute curvature for a circular arc
+
+- **GIVEN** a semicircular arc with radius R
+- **WHEN** `get_curvature(points)` is called
+- **THEN** all returned curvature values are approximately 1/R
+
+### Requirement: Fourier Coefficient Extraction
+
+The system SHALL compute Fourier coefficients from 1D signals using the Fast Fourier Transform.
+
+#### Scenario: Extract specified number of harmonics
+
+- **GIVEN** a 1D signal of arbitrary length
+- **WHEN** `get_fourier_coefficients(signal, n_harmonics=5)` is called
+- **THEN** the function returns an array of length 10 (2 values per harmonic)
+
+#### Scenario: Fourier coefficients capture shape information
+
+- **GIVEN** two polylines with visually different shapes
+- **WHEN** Fourier descriptors are computed for both
+- **THEN** the resulting descriptor vectors have different values

--- a/openspec/changes/add-fourier-shape-descriptors/tasks.md
+++ b/openspec/changes/add-fourier-shape-descriptors/tasks.md
@@ -1,0 +1,41 @@
+# Tasks: Add Fourier Shape Descriptors
+
+## 1. Core Implementation
+
+- [ ] 1.1 Create `sleap_roots/fourier.py` module with docstring header
+- [ ] 1.2 Implement `get_arc_length_parameterization()` - resample polyline to uniform arc length
+- [ ] 1.3 Implement `get_tangent_angles()` - compute tangent angle θ(s) along curve
+- [ ] 1.4 Implement `get_fourier_coefficients()` - FFT of tangent angle function
+- [ ] 1.5 Implement `get_curvature()` - compute curvature κ(s) = dθ/ds
+- [ ] 1.6 Implement `get_fourier_descriptors()` - main API returning fixed-length embedding
+- [ ] 1.7 Add normalization options (rotation-invariant, scale-invariant)
+
+## 2. Integration
+
+- [ ] 2.1 Add exports to `sleap_roots/__init__.py`
+- [ ] 2.2 Create `TraitDef` entries for Fourier descriptors in pipeline (optional)
+- [ ] 2.3 Add `fourier_embedding` as optional computed trait in pipelines
+
+## 3. Testing
+
+- [ ] 3.1 Create `tests/test_fourier.py` with unit tests
+- [ ] 3.2 Test arc-length parameterization correctness
+- [ ] 3.3 Test tangent angle computation on known shapes (straight line, semicircle)
+- [ ] 3.4 Test Fourier coefficient properties (conjugate symmetry, Parseval's theorem)
+- [ ] 3.5 Test invariance properties (translation, rotation, scale)
+- [ ] 3.6 Test handling of edge cases (NaN values, short roots, single-point roots)
+- [ ] 3.7 Integration test with real root data from test fixtures
+
+## 4. Documentation
+
+- [ ] 4.1 Add Google-style docstrings to all public functions
+- [ ] 4.2 Add module-level docstring explaining the methodology
+- [ ] 4.3 Update `docs/api/traits/` with Fourier descriptor documentation
+- [ ] 4.4 Add usage examples in docstrings
+
+## 5. Validation
+
+- [ ] 5.1 Run Black formatting check
+- [ ] 5.2 Run pydocstyle check
+- [ ] 5.3 Run full test suite
+- [ ] 5.4 Verify no regressions in existing traits


### PR DESCRIPTION
## Summary

- Add OpenSpec proposal for Fourier-based shape descriptors that encode root polyline morphology into fixed-length vectors
- Enables ML-ready embeddings for classification, clustering, and phenotype discovery
- Based on established biological morphometrics (C. elegans eigenworms, cell shape analysis)

## Motivation

Current trait extraction provides ~40 interpretable metrics, but researchers need:
1. **ML-ready embeddings** - fixed-length vectors for downstream models
2. **Unsupervised discovery** - find shape patterns not captured by predefined traits
3. **Compact representation** - encode full morphology in a vector

## Approach

**Tangent angle parameterization** (from worm morphology research):
- Represent root as θ(s) - tangent angle as function of arc length
- Apply Fourier transform to get fixed-length coefficients
- Works on open curves (unlike Elliptic Fourier Descriptors which need closed contours)

## What's Included

| File | Description |
|------|-------------|
| `proposal.md` | Problem statement, research background, impact |
| `design.md` | Technical decisions, API design, trade-offs |
| `tasks.md` | Implementation checklist (19 tasks) |
| `specs/trait-computation/spec.md` | Requirements with test scenarios |

## Key Design Decisions

- **NumPy only** - no new dependencies
- **10 harmonics default** → 20-dimensional embedding per root
- **Arc-length resampling** - normalizes variable SLEAP predictions
- **Rotation invariant** - subtract mean angle

## Research References

- Stephens et al. "Dimensionality and Dynamics in C. elegans" (PLOS Comp Bio)
- Kriegel et al. "Cell shape with discrete Fourier transforms" (Cytometry)
- MPEG-7 Curvature Scale Space standard

## Test plan

- [ ] Review proposal and design documents
- [ ] Discuss any open questions (output format, pipeline integration)
- [ ] Approve for implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)