### PR TITLE
test: Add pixel unit regression test (fixes #146)

### DIFF
--- a/.claude/commands/copilot-review.md
+++ b/.claude/commands/copilot-review.md
@@ -1,0 +1,105 @@
+# View GitHub Copilot Review Comments
+
+**Quick command to view all GitHub Copilot inline code review comments for a PR**
+
+## Quick Usage (GraphQL - Recommended)
+
+```bash
+# For specific PR number (simpler, more reliable)
+gh api graphql -f query='
+query {
+  repository(owner: "talmolab", name: "sleap-roots") {
+    pullRequest(number: PR_NUMBER) {
+      reviews(first: 10) {
+        nodes {
+          author { login }
+          comments(first: 50) {
+            nodes {
+              path
+              line
+              body
+            }
+          }
+        }
+      }
+    }
+  }
+}
+' --jq '.data.repository.pullRequest.reviews.nodes[] | select(.author.login | contains("opilot")) | .comments.nodes[] | "File: \(.path):\(.line)\n\(.body)\n" + ("="*80)'
+```
+
+## Alternative: REST API
+
+```bash
+# View Copilot comments for specific PR (REST API)
+gh api repos/talmolab/sleap-roots/pulls/PR_NUMBER/comments --jq '.[] | "File: \(.path):\(.line // .original_line)\n\(.body)\n" + ("="*80)'
+
+# For current PR dynamically
+gh api repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/pulls/$(gh pr view --json number -q .number)/comments --jq '.[] | "File: \(.path):\(.line // .original_line)\n\(.body)\n" + ("="*80)'
+```
+
+## What This Does
+
+1. Fetches all inline code review comments from Copilot
+2. Formats each comment showing:
+   - File path and line number
+   - Comment body
+   - Separator line between comments
+
+## Important Notes
+
+- GitHub Copilot inline comments come from user **"Copilot"**
+- Review summaries come from **"copilot-pull-request-reviewer[bot]"**
+- GraphQL approach can fetch both in one query (more efficient)
+- REST API requires separate calls for reviews vs comments
+
+## Get Review Summary
+
+To see the overall review summary from Copilot:
+
+```bash
+# GraphQL (gets review body + inline comments in one call)
+gh api graphql -f query='
+query {
+  repository(owner: "talmolab", name: "sleap-roots") {
+    pullRequest(number: PR_NUMBER) {
+      reviews(first: 10) {
+        nodes {
+          author { login }
+          state
+          body
+          submittedAt
+        }
+      }
+    }
+  }
+}
+' --jq '.data.repository.pullRequest.reviews.nodes[] | select(.author.login | contains("opilot")) | {state, submitted: .submittedAt, body}'
+
+# REST API
+gh api repos/talmolab/sleap-roots/pulls/PR_NUMBER/reviews --jq '.[] | select(.user.login | contains("copilot")) | {state: .state, submitted_at: .submitted_at, body: .body}'
+```
+
+## Typical Copilot Comments Include
+
+- Code quality suggestions
+- Error handling improvements
+- Type safety recommendations
+- Best practice violations
+- Inconsistencies with documented patterns
+- Missing edge case handling
+
+## Integration with Pre-Merge Checks
+
+This command should be run as part of the pre-merge workflow (Phase 6: Review Feedback) to ensure all Copilot feedback is addressed before merging.
+
+## Example Output
+
+```
+File: sleap_roots/trait_pipelines.py:310
+Empty string fallback for optional genotype_id creates inconsistent data. Should use `null` or `None` for missing optional values...
+================================================================================
+File: sleap_roots/lengths.py:56
+Missing error handling when computation fails. If the result is None, downstream code has no feedback...
+================================================================================
+```

--- a/openspec/changes/add-pixel-unit-regression-test/proposal.md
+++ b/openspec/changes/add-pixel-unit-regression-test/proposal.md
@@ -1,0 +1,28 @@
+# Proposal: Add Pixel Unit Regression Test
+
+**Change ID:** `add-pixel-unit-regression-test`
+**Status:** PROPOSED
+**Issue:** https://github.com/talmolab/sleap-roots/issues/146
+
+## Why
+
+If a dependency (sleap-io, PIL, h5py) ever auto-converts pixel coordinates based on image DPI metadata, every trait calculation would silently produce wrong values — a ~47x error at 1200 DPI that could go undetected. This defensive regression test guards against that at multiple layers: data loading, pipeline orchestration, and trait computation.
+
+## What Changes
+
+Add a new test module `tests/test_pixel_units.py` that:
+
+1. Creates a synthetic TIFF image (200x400, 1200 DPI metadata) using Pillow
+2. Creates synthetic sleap-io objects (Skeleton, Instance, LabeledFrame, Labels) with two nodes 100px apart
+3. Constructs a `Series` object with these synthetic predictions
+4. Runs through `PrimaryRootPipeline` end-to-end
+5. Asserts `primary_length` = 100.0 (pixels), not ~2.12 (mm)
+6. Also tests `get_root_lengths()` and `get_base_tip_dist()` directly as contract tests
+
+## Impact
+
+- Affected specs: pixel-unit-invariance (new capability)
+- Affected code: `tests/test_pixel_units.py` (new), exercises `sleap_roots/lengths.py`, `sleap_roots/bases.py`, `sleap_roots/trait_pipelines.py` (PrimaryRootPipeline), `sleap_roots/series.py`
+- Risk: None — test-only change with no production code modifications
+- Backward compatibility: No impact
+- Reproducibility: Strengthens reproducibility by preventing silent unit drift

--- a/openspec/changes/add-pixel-unit-regression-test/proposal.md
+++ b/openspec/changes/add-pixel-unit-regression-test/proposal.md
@@ -3,26 +3,33 @@
 **Change ID:** `add-pixel-unit-regression-test`
 **Status:** PROPOSED
 **Issue:** https://github.com/talmolab/sleap-roots/issues/146
+**Related:** https://github.com/talmolab/sleap-roots/issues/150 (get_node_ind 2-node crash)
 
 ## Why
 
-If a dependency (sleap-io, PIL, h5py) ever auto-converts pixel coordinates based on image DPI metadata, every trait calculation would silently produce wrong values — a ~47x error at 1200 DPI that could go undetected. This defensive regression test guards against that at multiple layers: data loading, pipeline orchestration, and trait computation.
+If a dependency (sleap-io, PIL, h5py) ever auto-converts pixel coordinates based on image DPI metadata, every trait calculation would silently produce wrong values — a ~47x error at 1200 DPI that could go undetected. This defensive regression test guards against that at multiple layers: **file I/O (TIFF backend open, .slp serialization)**, data loading (`sio.load_slp`, `Series.load`), pipeline orchestration, and trait computation.
 
 ## What Changes
 
 Add a new test module `tests/test_pixel_units.py` that:
 
 1. Creates a synthetic TIFF image (200x400, 1200 DPI metadata) using Pillow
-2. Creates synthetic sleap-io objects (Skeleton, Instance, LabeledFrame, Labels) with two nodes 100px apart
-3. Constructs a `Series` object with these synthetic predictions
-4. Runs through `PrimaryRootPipeline` end-to-end
-5. Asserts `primary_length` = 100.0 (pixels), not ~2.12 (mm)
-6. Also tests `get_root_lengths()` and `get_base_tip_dist()` directly as contract tests
+2. Opens the TIFF via `sio.Video.from_filename()` (forcing the backend to read file metadata)
+3. Creates synthetic sleap-io objects (Skeleton, Instance, LabeledFrame, Labels) with a 6-node primary root spanning 100px vertically
+4. Serializes the Labels to a `.slp` file via `sio.save_slp()`
+5. Reloads the `.slp` via `Series.load(primary_path=...)` — exercising the full I/O layer
+6. Runs through `PrimaryRootPipeline` end-to-end
+7. Asserts `primary_length` = 100.0 (pixels), not ~2.12 (mm)
+8. Also tests `get_root_lengths()` and `get_base_tip_dist()` directly as contract tests
+
+### Why 6 nodes instead of 2?
+
+Issue #146 describes the minimal case as "two nodes 100px apart", but `PrimaryRootPipeline` computes angle traits (`primary_angle_proximal`, `primary_angle_distal`) that call `get_node_ind()`, which crashes on roots with fewer than 3 nodes (see [#150](https://github.com/talmolab/sleap-roots/issues/150)). To exercise the full pipeline end-to-end, this test uses a 6-node primary root with nodes evenly spaced 20px apart (total length 100px). The unit-level contract tests for `get_root_lengths()` and `get_base_tip_dist()` still use the minimal 2-node case.
 
 ## Impact
 
 - Affected specs: pixel-unit-invariance (new capability)
-- Affected code: `tests/test_pixel_units.py` (new), exercises `sleap_roots/lengths.py`, `sleap_roots/bases.py`, `sleap_roots/trait_pipelines.py` (PrimaryRootPipeline), `sleap_roots/series.py`
+- Affected code: `tests/test_pixel_units.py` (new), exercises `sleap_roots/lengths.py`, `sleap_roots/bases.py`, `sleap_roots/trait_pipelines.py` (PrimaryRootPipeline), `sleap_roots/series.py`, and the `sio.save_slp` / `sio.load_slp` round-trip
 - Risk: None — test-only change with no production code modifications
 - Backward compatibility: No impact
-- Reproducibility: Strengthens reproducibility by preventing silent unit drift
+- Reproducibility: Strengthens reproducibility by preventing silent unit drift at every layer from file I/O through trait output

--- a/openspec/changes/add-pixel-unit-regression-test/specs/pixel-unit-invariance/spec.md
+++ b/openspec/changes/add-pixel-unit-regression-test/specs/pixel-unit-invariance/spec.md
@@ -1,19 +1,21 @@
 # Capability: Pixel Unit Invariance
 
-Trait calculations MUST produce results in pixel units regardless of image DPI metadata.
+Trait calculations MUST produce results in pixel units regardless of image DPI metadata, at every layer from file I/O through trait output.
 
 ## ADDED Requirements
 
-### Requirement: Pipeline MUST return pixel-unit trait values regardless of source image DPI metadata
+### Requirement: Pipeline MUST return pixel-unit trait values regardless of source image DPI metadata, end-to-end through .slp serialization
 
-The full pipeline — from data loading through trait computation — MUST produce trait values in pixel units. No layer (image loading, coordinate extraction, pipeline orchestration, or trait computation) SHALL apply DPI-based unit conversion.
+The full data path — image I/O, `.slp` serialization, `sio.load_slp()`, `Series.load()`, pipeline orchestration, and trait computation — MUST produce trait values in pixel units. No layer SHALL apply DPI-based unit conversion.
 
-#### Scenario: Primary root length through PrimaryRootPipeline is in pixels, not DPI-converted mm
+#### Scenario: Primary root length through full load+pipeline round-trip is in pixels, not DPI-converted mm
 
 - **Given** a synthetic TIFF image of size 200x400 with 1200 DPI metadata created via Pillow
-- **And** a synthetic sleap-io Labels object with a Skeleton containing two nodes
-- **And** an Instance with node coordinates at (100, 50) and (100, 150), representing a 100px vertical root
-- **And** a Series object constructed from these synthetic predictions
+- **And** the TIFF is opened via `sio.Video.from_filename()`, forcing the backend to read file metadata
+- **And** a synthetic sleap-io Labels object with a 6-node Skeleton
+- **And** an Instance with node coordinates spanning (100, 50) to (100, 150), 100px vertically
+- **And** the Labels are serialized to a `.slp` file via `sio.save_slp()`
+- **And** the `.slp` file is reloaded via `Series.load(primary_path=...)`
 - **When** `PrimaryRootPipeline().compute_plant_traits(series)` is called
 - **Then** the `primary_length` column value is 100.0 (pixels)
 - **And** the `primary_base_tip_dist` column value is 100.0 (pixels)

--- a/openspec/changes/add-pixel-unit-regression-test/specs/pixel-unit-invariance/spec.md
+++ b/openspec/changes/add-pixel-unit-regression-test/specs/pixel-unit-invariance/spec.md
@@ -1,0 +1,44 @@
+# Capability: Pixel Unit Invariance
+
+Trait calculations MUST produce results in pixel units regardless of image DPI metadata.
+
+## ADDED Requirements
+
+### Requirement: Pipeline MUST return pixel-unit trait values regardless of source image DPI metadata
+
+The full pipeline — from data loading through trait computation — MUST produce trait values in pixel units. No layer (image loading, coordinate extraction, pipeline orchestration, or trait computation) SHALL apply DPI-based unit conversion.
+
+#### Scenario: Primary root length through PrimaryRootPipeline is in pixels, not DPI-converted mm
+
+- **Given** a synthetic TIFF image of size 200x400 with 1200 DPI metadata created via Pillow
+- **And** a synthetic sleap-io Labels object with a Skeleton containing two nodes
+- **And** an Instance with node coordinates at (100, 50) and (100, 150), representing a 100px vertical root
+- **And** a Series object constructed from these synthetic predictions
+- **When** `PrimaryRootPipeline().compute_plant_traits(series)` is called
+- **Then** the `primary_length` column value is 100.0 (pixels)
+- **And** the `primary_base_tip_dist` column value is 100.0 (pixels)
+- **And** neither value is approximately 2.117 (which would be 100px / 1200 DPI * 25.4 mm/inch)
+
+#### Scenario: Root length computation function returns pixel values for straight segments
+
+- **Given** a synthetic numpy array of shape (1, 2, 2) with nodes at (100, 50) and (100, 150)
+- **When** `get_root_lengths()` is called with this array
+- **Then** the result is the scalar 100.0 (pixels)
+
+#### Scenario: Root length computation function returns pixel values for polyline roots
+
+- **Given** a synthetic numpy array with 3 nodes forming an L-shape: (0, 0), (0, 60), (80, 60)
+- **When** `get_root_lengths()` is called with this array
+- **Then** the result is 140.0 (pixels), the sum of segment lengths 60 + 80
+
+#### Scenario: Base-to-tip distance is computed in pixels
+
+- **Given** a synthetic base point array at (100, 50) and tip point array at (100, 150)
+- **When** `get_base_tip_dist()` is called with these separate arrays
+- **Then** the result is 100.0 (pixels)
+
+#### Scenario: Multi-instance root lengths are all in pixel units
+
+- **Given** a synthetic numpy array of shape (3, 2, 2) with 3 root instances: nodes [(0,0),(0,100)], [(0,0),(0,50)], [(0,0),(0,75)]
+- **When** `get_root_lengths()` is called with this array
+- **Then** the returned array is [100.0, 50.0, 75.0] in pixels

--- a/openspec/changes/add-pixel-unit-regression-test/tasks.md
+++ b/openspec/changes/add-pixel-unit-regression-test/tasks.md
@@ -2,16 +2,20 @@
 
 ## 1. Create test module with pixel unit regression tests
 
-- [x] 1.1 Create `tests/test_pixel_units.py` with integration test: synthetic TIFF (200x400, 1200 DPI) + synthetic sleap-io Labels + Series + PrimaryRootPipeline → assert `primary_length` == 100.0 pixels
+- [x] 1.1 Create `tests/test_pixel_units.py` with integration test: synthetic TIFF (200x400, 1200 DPI) opened via `sio.Video.from_filename()` + 6-node sleap-io Labels + `sio.save_slp()` + `Series.load()` + `PrimaryRootPipeline` → assert `primary_length` == 100.0 pixels
 - [x] 1.2 Add unit-level contract tests: `test_root_length_straight`, `test_root_length_polyline`, `test_base_tip_dist_in_pixels`, `test_multi_instance_lengths`
 - [x] 1.3 Run `uv run pytest tests/test_pixel_units.py -v` and verify all pass
 
 ## 2. Verify no regressions
 
-- [x] 2.1 Run `uv run pytest tests/ -x` and verify full suite passes (411 passed)
+- [x] 2.1 Run `uv run pytest tests/ -x` and verify full suite passes
 - [x] 2.2 Run `uv run black --check sleap_roots/ tests/` and verify formatting
 
 ## Dependencies
 
 - Task 2 depends on Task 1
 - No parallelizable work (single test file)
+
+## Notes
+
+- The integration test uses a 6-node primary root (not 2 nodes as in the original issue description) because `PrimaryRootPipeline` computes angle traits via `get_node_ind()`, which crashes on roots with fewer than 3 nodes. This is tracked as a separate bug in issue #150.

--- a/openspec/changes/add-pixel-unit-regression-test/tasks.md
+++ b/openspec/changes/add-pixel-unit-regression-test/tasks.md
@@ -1,0 +1,17 @@
+# Tasks: Add Pixel Unit Regression Test
+
+## 1. Create test module with pixel unit regression tests
+
+- [x] 1.1 Create `tests/test_pixel_units.py` with integration test: synthetic TIFF (200x400, 1200 DPI) + synthetic sleap-io Labels + Series + PrimaryRootPipeline → assert `primary_length` == 100.0 pixels
+- [x] 1.2 Add unit-level contract tests: `test_root_length_straight`, `test_root_length_polyline`, `test_base_tip_dist_in_pixels`, `test_multi_instance_lengths`
+- [x] 1.3 Run `uv run pytest tests/test_pixel_units.py -v` and verify all pass
+
+## 2. Verify no regressions
+
+- [x] 2.1 Run `uv run pytest tests/ -x` and verify full suite passes (411 passed)
+- [x] 2.2 Run `uv run black --check sleap_roots/ tests/` and verify formatting
+
+## Dependencies
+
+- Task 2 depends on Task 1
+- No parallelizable work (single test file)

--- a/tests/test_pixel_units.py
+++ b/tests/test_pixel_units.py
@@ -23,18 +23,24 @@ DPI_WRONG_VALUE = 100.0 / 1200 * 25.4  # ~2.117mm at 1200 DPI
 
 @pytest.fixture
 def synthetic_series(tmp_path):
-    """Create a Series with a synthetic 1200 DPI TIFF and known pixel coordinates.
+    """Create a Series by round-tripping synthetic data through .slp and Series.load.
+
+    Exercises the full I/O layer where DPI-aware coordinate scaling could be
+    introduced: TIFF backend open (via sio.Video.from_filename), sio.save_slp
+    serialization, sio.load_slp deserialization, and Series.load.
 
     The TIFF is 200x400 with 1200 DPI metadata. A 6-node primary root skeleton
     spans 100px vertically (nodes evenly spaced 20px apart from y=50 to y=150).
+    Six nodes are required because PrimaryRootPipeline computes angle traits
+    via get_node_ind(), which crashes on roots with fewer than 3 nodes (#150).
     """
-    # Create synthetic TIFF with 1200 DPI metadata
     img_array = np.zeros((400, 200), dtype=np.uint8)
-    img = Image.fromarray(img_array)
-    tif_path = str(tmp_path / "test_1200dpi.tif")
-    img.save(tif_path, dpi=(1200, 1200))
+    tif_path = tmp_path / "test_1200dpi.tif"
+    Image.fromarray(img_array).save(tif_path.as_posix(), dpi=(1200, 1200))
 
-    # Create sleap-io objects with known pixel coordinates
+    # Open TIFF via backend so video metadata is populated for .slp serialization
+    video = sio.Video.from_filename(tif_path.as_posix())
+
     skeleton = sio.Skeleton(nodes=[sio.Node(f"node_{i}") for i in range(6)])
     pts = np.array(
         [
@@ -47,11 +53,16 @@ def synthetic_series(tmp_path):
         ]
     )
     inst = sio.Instance.from_numpy(pts, skeleton=skeleton)
-    video = sio.Video(tif_path, open_backend=False)
     lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[inst])
     labels = sio.Labels(labeled_frames=[lf], skeletons=[skeleton], videos=[video])
 
-    return Series(series_name="synthetic_dpi_test", primary_labels=labels)
+    # Serialize to .slp and reload via Series.load to exercise the I/O path
+    slp_path = tmp_path / "synthetic.primary.predictions.slp"
+    sio.save_slp(labels, slp_path.as_posix())
+
+    return Series.load(
+        series_name="synthetic_dpi_test", primary_path=slp_path.as_posix()
+    )
 
 
 class TestPipelinePixelUnits:

--- a/tests/test_pixel_units.py
+++ b/tests/test_pixel_units.py
@@ -1,0 +1,112 @@
+"""Regression tests for pixel unit invariance.
+
+Guards against silent DPI-to-mm auto-conversion in trait calculations.
+If a dependency (sleap-io, PIL, h5py) ever converts pixel coordinates based
+on image DPI metadata, these tests will fail.
+
+See: https://github.com/talmolab/sleap-roots/issues/146
+"""
+
+import numpy as np
+import pytest
+import sleap_io as sio
+from PIL import Image
+
+from sleap_roots import PrimaryRootPipeline, Series
+from sleap_roots.bases import get_base_tip_dist
+from sleap_roots.lengths import get_root_lengths
+
+
+# DPI conversion that should NEVER be applied
+DPI_WRONG_VALUE = 100.0 / 1200 * 25.4  # ~2.117mm at 1200 DPI
+
+
+@pytest.fixture
+def synthetic_series(tmp_path):
+    """Create a Series with a synthetic 1200 DPI TIFF and known pixel coordinates.
+
+    The TIFF is 200x400 with 1200 DPI metadata. A 6-node primary root skeleton
+    spans 100px vertically (nodes evenly spaced 20px apart from y=50 to y=150).
+    """
+    # Create synthetic TIFF with 1200 DPI metadata
+    img_array = np.zeros((400, 200), dtype=np.uint8)
+    img = Image.fromarray(img_array)
+    tif_path = str(tmp_path / "test_1200dpi.tif")
+    img.save(tif_path, dpi=(1200, 1200))
+
+    # Create sleap-io objects with known pixel coordinates
+    skeleton = sio.Skeleton(nodes=[sio.Node(f"node_{i}") for i in range(6)])
+    pts = np.array(
+        [
+            [100.0, 50.0],
+            [100.0, 70.0],
+            [100.0, 90.0],
+            [100.0, 110.0],
+            [100.0, 130.0],
+            [100.0, 150.0],
+        ]
+    )
+    inst = sio.Instance.from_numpy(pts, skeleton=skeleton)
+    video = sio.Video(tif_path, open_backend=False)
+    lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[inst])
+    labels = sio.Labels(labeled_frames=[lf], skeletons=[skeleton], videos=[video])
+
+    return Series(series_name="synthetic_dpi_test", primary_labels=labels)
+
+
+class TestPipelinePixelUnits:
+    """Integration test: full pipeline with 1200 DPI TIFF metadata."""
+
+    def test_primary_length_in_pixels(self, synthetic_series):
+        """Primary root length through PrimaryRootPipeline must be in pixels."""
+        pipeline = PrimaryRootPipeline()
+        traits = pipeline.compute_plant_traits(synthetic_series)
+
+        primary_length = traits["primary_length"].values[0]
+        assert primary_length == pytest.approx(100.0)
+        assert primary_length != pytest.approx(DPI_WRONG_VALUE)
+
+    def test_primary_base_tip_dist_in_pixels(self, synthetic_series):
+        """Base-to-tip distance through PrimaryRootPipeline must be in pixels."""
+        pipeline = PrimaryRootPipeline()
+        traits = pipeline.compute_plant_traits(synthetic_series)
+
+        base_tip_dist = traits["primary_base_tip_dist"].values[0]
+        assert base_tip_dist == pytest.approx(100.0)
+        assert base_tip_dist != pytest.approx(DPI_WRONG_VALUE)
+
+
+class TestTraitFunctionPixelUnits:
+    """Unit-level contract tests: trait functions return pixel values."""
+
+    def test_root_length_straight(self):
+        """Straight 2-node root of 100px returns 100.0."""
+        pts = np.array([[[100.0, 50.0], [100.0, 150.0]]])
+        result = get_root_lengths(pts)
+        assert result == pytest.approx(100.0)
+
+    def test_root_length_polyline(self):
+        """L-shaped 3-node root returns sum of segment lengths in pixels."""
+        # Vertical segment (60px) + horizontal segment (80px) = 140px
+        pts = np.array([[[0.0, 0.0], [0.0, 60.0], [80.0, 60.0]]])
+        result = get_root_lengths(pts)
+        assert result == pytest.approx(140.0)
+
+    def test_base_tip_dist_in_pixels(self):
+        """Base-to-tip Euclidean distance returns pixel value."""
+        base_pts = np.array([100.0, 50.0])
+        tip_pts = np.array([100.0, 150.0])
+        result = get_base_tip_dist(base_pts, tip_pts)
+        assert result == pytest.approx(100.0)
+
+    def test_multi_instance_lengths(self):
+        """Multiple root instances all return pixel-unit lengths."""
+        pts = np.array(
+            [
+                [[0.0, 0.0], [0.0, 100.0]],
+                [[0.0, 0.0], [0.0, 50.0]],
+                [[0.0, 0.0], [0.0, 75.0]],
+            ]
+        )
+        result = get_root_lengths(pts)
+        np.testing.assert_array_almost_equal(result, [100.0, 50.0, 75.0])


### PR DESCRIPTION
## Summary

- Adds defensive regression test ensuring all trait calculations return pixel-unit values regardless of image DPI metadata
- Integration test creates synthetic TIFF (200x400, 1200 DPI) + sleap-io Labels + Series, runs through `PrimaryRootPipeline`, asserts `primary_length` = 100.0px (not 2.12mm)
- Unit-level contract tests for `get_root_lengths()` (straight, polyline, multi-instance) and `get_base_tip_dist()`
- Includes OpenSpec proposal (`add-pixel-unit-regression-test`)

## Context

Real-world TIFFs from circumnutation experiments have 400 DPI metadata embedded — entirely meaningless for camera captures but present in the headers. If any dependency (sleap-io, PIL, h5py) ever auto-converts pixel coordinates based on DPI metadata, every trait value would be silently wrong by ~47x. This test guards against that at multiple layers.

## Test plan

- [x] 6 new tests in `tests/test_pixel_units.py` all pass
- [x] Full suite: 411 passed, 0 failed
- [x] Coverage: 86% (maintained)
- [x] Black formatting: PASS
- [x] Pydocstyle: PASS
- [x] OpenSpec validates: `openspec validate add-pixel-unit-regression-test --strict`

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)