### PR TITLE
feat: Make expected_count optional in filter_plants_with_unexpected_ct (#125)

### DIFF
--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -373,11 +373,25 @@ After ALL subagents return:
 4. **Post the review to GitHub**:
 
 > **Note:** GitHub does not allow requesting changes or approving your own PRs.
-> Always attempt the desired action first; if it fails with "Can not request changes on your own pull request"
-> or "Can not approve your own pull request", automatically fall back to `--comment` with the same body
-> and a note at the top indicating the intended verdict.
+> Before posting, detect whether the PR is your own by comparing the PR author to the
+> authenticated user. If it's your own PR, skip the `--approve`/`--request-changes` attempt
+> entirely and go straight to `--comment` with a verdict banner. This avoids noisy
+> `GraphQL: Review Can not approve your own pull request` errors in the output.
 
-For REQUEST_CHANGES (attempt first, fall back to --comment on own-PR error):
+**Step 1: Detect own-PR upfront** (run once before posting):
+
+```bash
+PR_AUTHOR=$(gh pr view $PR_NUMBER --json author --jq '.author.login')
+GH_USER=$(gh api user --jq '.login')
+IS_OWN_PR=false
+if [ "$PR_AUTHOR" = "$GH_USER" ]; then
+  IS_OWN_PR=true
+fi
+```
+
+**Step 2: Post the review** using the appropriate method based on `$IS_OWN_PR`:
+
+For REQUEST_CHANGES:
 
 ```bash
 BODY="$(cat <<'EOF'
@@ -402,11 +416,14 @@ BODY="$(cat <<'EOF'
 EOF
 )"
 
-gh pr review $PR_NUMBER --request-changes -b "$BODY" 2>&1 || \
-gh pr review $PR_NUMBER --comment -b "$(printf '> **Verdict: REQUEST\_CHANGES** (posted as comment — GitHub does not allow requesting changes on your own PR)\n\n%s' "$BODY")"
+if [ "$IS_OWN_PR" = "true" ]; then
+  gh pr review $PR_NUMBER --comment -b "$(printf '> **Verdict: REQUEST_CHANGES** (posted as comment — cannot request changes on your own PR)\n\n%s' "$BODY")"
+else
+  gh pr review $PR_NUMBER --request-changes -b "$BODY"
+fi
 ```
 
-For APPROVE (attempt first, fall back to --comment on own-PR error):
+For APPROVE:
 
 ```bash
 BODY="$(cat <<'EOF'
@@ -423,11 +440,14 @@ BODY="$(cat <<'EOF'
 EOF
 )"
 
-gh pr review $PR_NUMBER --approve -b "$BODY" 2>&1 || \
-gh pr review $PR_NUMBER --comment -b "$(printf '> **Verdict: APPROVE** (posted as comment — GitHub does not allow approving your own PR)\n\n%s' "$BODY")"
+if [ "$IS_OWN_PR" = "true" ]; then
+  gh pr review $PR_NUMBER --comment -b "$(printf '> **Verdict: APPROVE** (posted as comment — cannot approve your own PR)\n\n%s' "$BODY")"
+else
+  gh pr review $PR_NUMBER --approve -b "$BODY"
+fi
 ```
 
-For COMMENT (no fallback needed):
+For COMMENT (no detection needed):
 
 ```bash
 gh pr review $PR_NUMBER --comment -b "..."

--- a/openspec/changes/make-expected-count-optional/proposal.md
+++ b/openspec/changes/make-expected-count-optional/proposal.md
@@ -1,0 +1,72 @@
+# Proposal: Make `expected_count` Optional
+
+**Change ID:** `make-expected-count-optional`
+**Status:** PROPOSED
+**Issue:** https://github.com/talmolab/sleap-roots/issues/125
+**Related (downstream):** https://github.com/talmolab/sleap-roots/issues/126 (`MultipleDicotPlatePipeline`)
+
+## Why
+
+`filter_plants_with_unexpected_ct()` in `sleap_roots/points.py` rejects `None` today. Its type check at [points.py:392](../../../sleap_roots/points.py#L392) — `if not np.issubdtype(type(expected_count), np.number)` — raises `ValueError` when given `None`. Callers must pass `np.nan` as a sentinel to mean "no expected count". This works today because `Series.expected_count` happens to return `np.nan` when the CSV is missing ([series.py:170](../../../sleap_roots/series.py#L170)), but:
+
+1. It is not Pythonic. A truly optional numeric parameter should accept `None`.
+2. Issue #126 (`MultipleDicotPlatePipeline`) will call this function from contexts where `None` is the natural "unknown" value. Blocking that with `ValueError` forces every future caller to shim `NaN`.
+3. The current signature advertises `expected_count: float` with no default — the NaN sentinel convention is undocumented at the signature level.
+
+Making `expected_count` a true `Optional[float] = None` motivates a cleaner API contract for issue #126 without disturbing the `MultipleDicotPipeline` cylinder workflow's filter-on-mismatch behavior, which is intentionally strict (~72-frame cylinder series can afford to drop mismatched frames; plates cannot, but that is #126's concern).
+
+### Scope narrowing relative to the current issue #125 body
+
+**Authorization.** The current text of issue #125 (titled *"Updated Spec: Optional Expected Count for Plates"*) lists `count_mismatch: True` / `count_validated` flagging and "include all plants on mismatch" as Required Changes and Acceptance Criteria. During the session that produced this proposal, the maintainer (@eberrigan) and the implementing agent reached an explicit verbal decision to **narrow the scope of issue #125 to the signature change only**, and to migrate the flagging work to issue #126 (`MultipleDicotPlatePipeline`). The reasoning recorded in that discussion:
+
+- **Cylinders and plates have different mismatch semantics.** `MultipleDicotPipeline` serves ~72-frame cylinder series where the "right" response to a count mismatch on a single frame is to drop that frame from per-series aggregation — there are plenty of other frames and the resulting summary stats stay clean. Plates have one image per timepoint; dropping a mismatched frame means losing the entire series. "Include all plants with a `count_mismatch` flag" is therefore load-bearing for plates but harmful for cylinders.
+- **`MultipleDicotPlatePipeline` (issue #126) is a new pipeline class with its own `define_traits()`.** It is the natural home for plate-specific "keep all plants and flag mismatch" semantics. Issue #126's current body already includes an *"Expected Count Behavior (#125)"* section that picks up the `count_mismatch` flag and `expected_count` optional-path requirements.
+- **Trying to bake both semantics into `filter_plants_with_unexpected_ct` would either break cylinder tests or require a `strict` kwarg that couples two pipelines through one function.** Keeping the cylinder function strict and letting the plate pipeline choose its own strategy (either skip the count-filter TraitDef entirely, or call a new flagging function) is cleaner.
+
+**Follow-up commitment.** Before this proposal is merged, a comment will be posted on issue #125 summarizing this scope split, explicitly transferring the `count_mismatch`/`count_validated` flagging and "include all plants on mismatch" acceptance criteria to issue #126. This records the out-of-band decision in GitHub so future readers see the scope split in the issue tracker, not only in this proposal.
+
+## What Changes
+
+1. **`sleap_roots/points.py` — `filter_plants_with_unexpected_ct`**
+   - Change signature from `expected_count: float` to `expected_count: Optional[float] = None`.
+   - Add an early-return branch: when `expected_count is None`, return both arrays unchanged — after the `np.ndarray` argument validation but before the numeric subdtype check (which would reject `type(None)`).
+   - Leave the existing NaN-skip branch (`if not np.isnan(expected_count):`) unchanged. `None` and `NaN` are now equivalent "skip filtering" signals.
+   - Leave the match branch (pass-through) unchanged.
+   - Leave the mismatch branch (return empty `(0, n_nodes, 2)` arrays) unchanged — `MultipleDicotPipeline` relies on this to drop frames from per-series aggregation.
+   - Update the docstring: document `expected_count` as `Optional[float] = None`, state explicitly that `None` and `NaN` both mean "skip filter", and describe the three numeric paths (match, mismatch, NaN).
+   - Non-numeric, non-`None` values (e.g. strings) continue to raise `ValueError`.
+
+2. **`sleap_roots/trait_pipelines.py` — `MultipleDicotPipeline`**
+   - **No code change.** The `expected_plant_ct` initial trait at [trait_pipelines.py:2695](../../../sleap_roots/trait_pipelines.py#L2695) is still sourced from `Series.expected_count`, which returns `np.nan` on missing CSV, and the broadened filter still treats NaN as "skip". This change only widens the function contract so that issue #126 can pass `None`.
+
+3. **Tests — `tests/test_points.py`**
+   - Add `test_filter_plants_with_unexpected_ct_none_expected_count`: passing `None` skips filter.
+   - Add `test_filter_plants_with_unexpected_ct_none_with_mismatched_shapes`: passing `None` when primary/lateral array instance counts differ still returns the full arrays (verifies `None` is not a stealth "match-required" path).
+   - Add `test_filter_plants_with_unexpected_ct_default_expected_count`: calling with only two positional arguments (relying on the new default) passes through.
+   - Keep existing tests (matching count, mismatching count, NaN, invalid string type) unchanged.
+
+4. **Tests — `tests/test_trait_pipelines.py`**
+   - Add `test_multiple_dicot_pipeline_without_csv`: use the existing `multiple_arabidopsis_11do_primary_slp` and `multiple_arabidopsis_11do_lateral_slp` fixtures from [tests/fixtures/data.py:179-187](../../../tests/fixtures/data.py#L179-L187) (do **not** pass the `multiple_arabidopsis_11do_csv` fixture). Call `Series.load(series_name="997_1", primary_path=..., lateral_path=...)` with no `csv_path` kwarg so `Series.expected_count` returns `np.nan`. Instantiate `pipeline = MultipleDicotPipeline()`. Then assert in order:
+     1. `np.isnan(series.expected_count)` is `True` (documents the precondition).
+     2. `result = pipeline.compute_multiple_dicots_traits(series)` completes without raising.
+     3. `set(result.keys()) == {"series", "group", "qc_fail", "traits", "summary_stats"}` — note this includes `qc_fail`, which the pipeline populates from `series.qc_fail` at [trait_pipelines.py:417](../../../sleap_roots/trait_pipelines.py#L417).
+     4. **Because `primary_pts_expected_plant_ct` is an `include_in_csv=False` per-frame TraitDef** at [trait_pipelines.py:2647-2654](../../../sleap_roots/trait_pipelines.py#L2647-L2654) and is discarded after each frame inside `compute_multiple_dicots_traits`, the per-frame non-empty assertion must invoke the pipeline directly frame-by-frame: `for frame_idx in range(len(series)): frame_traits = pipeline.compute_frame_traits(pipeline.get_initial_frame_traits(series, frame_idx))`. Collect the `frame_traits["primary_pts_expected_plant_ct"].shape[0]` values across all frames and assert `max(...) >= 1`. Looping across all frames (rather than hard-coding `frame_idx == 0`) avoids flakiness from per-sample labeling drift where a specific frame has all-NaN predictions.
+
+## What is explicitly NOT in scope
+
+- **No `count_mismatch: True` flagging.** See the "Scope narrowing" section in `## Why` above — this was the result of an explicit maintainer decision in the session that produced this proposal, with the work transferred to issue #126.
+- **No `count_validated` flag** either (also part of issue #125's original acceptance criteria) — same reasoning, same transfer target.
+- **No warning log on mismatch** (also part of issue #125's original acceptance criteria) — same reasoning, same transfer target.
+- **No change to `Series.expected_count`.** It still returns `np.nan` for missing CSV and for series not found in the CSV. Promoting it to `Optional[int]` or distinguishing "CSV absent" from "CSV present but series missing" is a separate concern with wider blast radius (Series tests, batch loaders, downstream CSV readers). If issue #126 needs that distinction, it will propose it separately.
+- **No rename of `filter_plants_with_unexpected_ct`.** The name still reflects its cylinder-pipeline role (drop mismatched frames from aggregation).
+- **No changes to `filter_primary_roots_with_unexpected_count`** — a sibling function at [points.py:408](../../../sleap_roots/points.py#L408) that is not called by `MultipleDicotPipeline` and is not in scope for issue #125. **Contract divergence note:** after this change, the two functions' type contracts diverge — `filter_plants_with_unexpected_ct` accepts `None`, `filter_primary_roots_with_unexpected_count` still rejects it. Documented here so a future reader doesn't assume symmetry.
+- **Spec `Requirement 2` is a regression baseline, not new behavior.** Because the `multiple-dicot-pipeline` capability is being created fresh (there was no prior spec file to MODIFY), pre-existing numeric semantics are expressed as ADDED requirements alongside the new `None` requirement. They are verbatim captures of today's behavior; no code change is proposed for them. This is called out inside the spec itself.
+
+## Impact
+
+- **Affected specs:** `multiple-dicot-pipeline` (new capability).
+- **Affected code:** `sleap_roots/points.py` (one signature change + one new branch + docstring), `tests/test_points.py` (3 new unit tests), `tests/test_trait_pipelines.py` (1 new integration test).
+- **Risk:** Very low. The only behavioral change is broadening the accepted input domain to include `None`; all existing inputs (numeric, NaN, invalid strings) behave identically. No existing caller passes `None`, so no regression surface.
+- **Backward compatibility:** Fully backward compatible.
+- **Reproducibility:** No effect on trait values for any existing workflow. The new `None` path produces the same output arrays as the existing NaN path.
+- **Enables #126 API cleanliness:** Issue #126 can call `filter_plants_with_unexpected_ct(..., expected_count=None)` without working around a `ValueError`, or construct its own pipeline that skips the count-filter TraitDef entirely. This is a cleanup motivated by #126, not a hard dependency — #126 could proceed today by passing `np.nan` — so this is not framed as "unblocking" #126.

--- a/openspec/changes/make-expected-count-optional/specs/multiple-dicot-pipeline/spec.md
+++ b/openspec/changes/make-expected-count-optional/specs/multiple-dicot-pipeline/spec.md
@@ -1,0 +1,114 @@
+# Capability: Multiple Dicot Pipeline
+
+The `MultipleDicotPipeline` computes root traits across multiple plants in a single series, with per-frame filtering that drops frames whose detected primary-root count does not match the expected plant count. This spec covers the contract of the per-plant count-filter function and the pipeline's tolerance for missing expected-count metadata.
+
+## ADDED Requirements
+
+### Requirement: `filter_plants_with_unexpected_ct` MUST accept `None` as "no expected count"
+
+The `filter_plants_with_unexpected_ct` function in `sleap_roots/points.py` SHALL accept `expected_count: Optional[float] = None`. When `expected_count` is `None`, the function MUST return both `primary_pts` and `lateral_pts` unchanged without performing any count check. The `None` path MUST be observationally equivalent to the existing `np.nan` "skip filtering" sentinel: both inputs yield pass-through output, and neither triggers the numeric-mismatch empty-array branch.
+
+#### Scenario: Calling with `expected_count=None` returns inputs unchanged
+
+- **Given** `primary_pts` of shape `(5, 10, 2)` populated with random values
+- **And** `lateral_pts` of shape `(5, 10, 2)` populated with random values
+- **When** `filter_plants_with_unexpected_ct(primary_pts, lateral_pts, expected_count=None)` is called
+- **Then** the returned primary array is element-wise equal to the input `primary_pts`
+- **And** the returned lateral array is element-wise equal to the input `lateral_pts`
+- **And** no exception is raised
+
+#### Scenario: `None` does not implicitly require matching primary/lateral counts
+
+- **Given** `primary_pts` of shape `(5, 10, 2)` and `lateral_pts` of shape `(3, 10, 2)` — different instance counts
+- **When** `filter_plants_with_unexpected_ct(primary_pts, lateral_pts, expected_count=None)` is called
+- **Then** the returned primary array has shape `(5, 10, 2)` — all 5 instances preserved
+- **And** the returned lateral array has shape `(3, 10, 2)` — all 3 instances preserved
+- **And** neither array is the empty `(0, 10, 2)` placeholder
+
+#### Scenario: `expected_count` defaults to `None` when omitted
+
+- **Given** `primary_pts` of shape `(5, 10, 2)` and `lateral_pts` of shape `(5, 10, 2)`
+- **When** `filter_plants_with_unexpected_ct(primary_pts, lateral_pts)` is called with exactly two positional arguments
+- **Then** the returned arrays are element-wise equal to the inputs
+- **And** no `TypeError` is raised for a missing `expected_count` argument
+
+### Requirement: Numeric `expected_count` filter semantics MUST be preserved
+
+This requirement captures the **existing** behavior of `filter_plants_with_unexpected_ct` for numeric `expected_count` values as a regression baseline for the new `multiple-dicot-pipeline` capability. Because no prior capability spec existed, these pre-existing semantics are expressed here as ADDED requirements so the broadened contract (Requirement 1) can coexist with them verifiably. The behavior MUST be preserved byte-for-byte to keep `MultipleDicotPipeline`'s drop-on-mismatch aggregation intact:
+
+- `np.nan` skips filtering and returns inputs unchanged.
+- A finite number equal to `round(expected_count) == len(primary_pts)` returns inputs unchanged.
+- A finite number with `round(expected_count) != len(primary_pts)` returns empty `(0, n_nodes, 2)` arrays for both primary and lateral.
+- Rounding MUST use Python's built-in `round()` (banker's rounding, half-to-even): `round(2.5) == 2`, `round(3.5) == 4`. This rule is pinned to prevent a future refactor (e.g. `int(round(...))` or `math.floor(x + 0.5)`) from silently changing drop/keep decisions on half-integer inputs.
+- A non-numeric, non-`None` value (e.g. a string) raises `ValueError`.
+
+#### Scenario: `np.nan` expected_count skips filtering
+
+- **Given** `primary_pts` of shape `(5, 10, 2)`, `lateral_pts` of shape `(5, 10, 2)`, and `expected_count=np.nan`
+- **When** `filter_plants_with_unexpected_ct` is called
+- **Then** both output arrays are element-wise equal to the inputs
+
+#### Scenario: Matching numeric expected_count passes arrays through
+
+- **Given** `primary_pts` of shape `(5, 10, 2)`, `lateral_pts` of shape `(5, 10, 2)`, and `expected_count=5.0`
+- **When** `filter_plants_with_unexpected_ct` is called
+- **Then** both output arrays are element-wise equal to the inputs
+
+#### Scenario: Mismatching numeric expected_count produces empty arrays
+
+- **Given** `primary_pts` of shape `(5, 10, 2)`, `lateral_pts` of shape `(5, 10, 2)`, and `expected_count=3.0`
+- **When** `filter_plants_with_unexpected_ct` is called
+- **Then** the returned primary array has shape `(0, 10, 2)`
+- **And** the returned lateral array has shape `(0, 10, 2)`
+
+#### Scenario: Non-numeric, non-None expected_count raises ValueError
+
+- **Given** `primary_pts` of shape `(5, 10, 2)`, `lateral_pts` of shape `(5, 10, 2)`, and `expected_count="not a float"`
+- **When** `filter_plants_with_unexpected_ct` is called
+- **Then** a `ValueError` is raised
+
+#### Scenario: `expected_count=0` with empty primary_pts passes through
+
+- **Given** `primary_pts` of shape `(0, 10, 2)` (no primary-root instances) and `lateral_pts` of shape `(0, 10, 2)`
+- **And** `expected_count=0`
+- **When** `filter_plants_with_unexpected_ct` is called
+- **Then** the returned primary array has shape `(0, 10, 2)` (pass-through, because `round(0) == 0 == len(primary_pts)`)
+- **And** the returned lateral array has shape `(0, 10, 2)`
+- **And** no `ValueError` is raised
+
+#### Scenario: `expected_count=0` with non-empty primary_pts produces empty arrays
+
+- **Given** `primary_pts` of shape `(3, 10, 2)`, `lateral_pts` of shape `(3, 10, 2)`, and `expected_count=0`
+- **When** `filter_plants_with_unexpected_ct` is called
+- **Then** the returned primary array has shape `(0, 10, 2)` (mismatch branch, `round(0) == 0 != 3`)
+- **And** the returned lateral array has shape `(0, 10, 2)`
+
+#### Scenario: Half-integer expected_count uses Python banker's rounding
+
+- **Given** `primary_pts` of shape `(2, 10, 2)`, `lateral_pts` of shape `(2, 10, 2)`, and `expected_count=2.5`
+- **When** `filter_plants_with_unexpected_ct` is called
+- **Then** both output arrays are element-wise equal to the inputs (because `round(2.5) == 2 == len(primary_pts)`)
+- **And given** `primary_pts` of shape `(4, 10, 2)`, `lateral_pts` of shape `(4, 10, 2)`, and `expected_count=3.5`
+- **When** `filter_plants_with_unexpected_ct` is called
+- **Then** both output arrays are element-wise equal to the inputs (because `round(3.5) == 4 == len(primary_pts)`)
+
+### Requirement: `MultipleDicotPipeline` MUST run end-to-end when `Series.expected_count` is unknown
+
+When `MultipleDicotPipeline` is executed against a `Series` whose `expected_count` property evaluates to `np.nan` (because the series was loaded without a `csv_path`, or the CSV does not list that series), the pipeline MUST complete without error and MUST NOT silently zero out plant-point arrays at the frame level. Specifically, at least one frame with a non-empty primary-root prediction MUST retain its detected primary instances after the count-filter TraitDef runs.
+
+Because the per-frame trait `primary_pts_expected_plant_ct` is declared `include_in_csv=False` on `MultipleDicotPipeline` and is therefore discarded after each frame's aggregation inside `compute_multiple_dicots_traits`, the per-frame assertion MUST be verified by invoking `pipeline.compute_frame_traits(pipeline.get_initial_frame_traits(series, frame_idx))` directly against the instantiated pipeline — not by inspecting the return value of `compute_multiple_dicots_traits(series)`.
+
+#### Scenario: `compute_multiple_dicots_traits` completes without error on a series loaded without a CSV
+
+- **Given** a `Series` loaded from `tests/data/multiple_arabidopsis_11do/` via `Series.load(series_name=..., primary_path=..., lateral_path=...)` with no `csv_path` argument
+- **And** `np.isnan(series.expected_count)` is `True`
+- **When** `MultipleDicotPipeline().compute_multiple_dicots_traits(series)` is called
+- **Then** the call returns a dict whose key set is exactly `{"series", "group", "qc_fail", "traits", "summary_stats"}`
+- **And** no `ValueError` is raised by the underlying `filter_plants_with_unexpected_ct` call
+
+#### Scenario: Per-frame `primary_pts_expected_plant_ct` is non-empty for a frame with primary predictions
+
+- **Given** the same `Series` (loaded without `csv_path`) and a `MultipleDicotPipeline()` instance
+- **When** for each `frame_idx` in `range(len(series))`, the test calls `frame_traits = pipeline.compute_frame_traits(pipeline.get_initial_frame_traits(series, frame_idx))`
+- **Then** for at least one `frame_idx`, `frame_traits["primary_pts_expected_plant_ct"].shape[0]` is greater than or equal to 1
+- **And** the test does NOT depend on `frame_idx == 0` specifically — the loop guarantees robustness against per-sample labeling drift where frame 0 happens to have no primary-root predictions

--- a/openspec/changes/make-expected-count-optional/tasks.md
+++ b/openspec/changes/make-expected-count-optional/tasks.md
@@ -1,0 +1,138 @@
+# Tasks: Make `expected_count` Optional
+
+## Pre-existing test coverage map (DO NOT add duplicate tests)
+
+Requirement 2 in the spec captures existing numeric semantics as a regression baseline. Four of its scenarios are already covered by existing tests in [tests/test_points.py](../../../tests/test_points.py):
+
+| Spec scenario | Existing test | Lines |
+|---|---|---|
+| `np.nan` skips filtering | `test_filter_plants_with_unexpected_ct_nan_expected_count` | 738-747 |
+| Matching numeric passes through | `test_filter_plants_with_unexpected_ct_valid_input_matching_count` | 714-723 |
+| Mismatching numeric produces empty arrays | `test_filter_plants_with_unexpected_ct_valid_input_non_matching_count` | 726-735 |
+| Non-numeric, non-None raises ValueError | `test_filter_plants_with_unexpected_ct_incorrect_input_types` | 750-767 |
+
+These tests MUST continue to pass unchanged after the implementation in section 2. Task 3.1 runs the full `test_points.py` file to verify this explicitly.
+
+## 1. Write failing tests first (TDD — `None` contract)
+
+- [x] 1.1 Add `test_filter_plants_with_unexpected_ct_none_expected_count` in `tests/test_points.py`. Create primary_pts (5, 10, 2) and lateral_pts (5, 10, 2) via `np.random.rand`, call `filter_plants_with_unexpected_ct(primary_pts, lateral_pts, expected_count=None)`, and assert both output arrays equal the inputs via `np.array_equal`. **Expected failure before implementation**: `ValueError("expected_count must be a numeric type.")` raised by the existing numeric subdtype check on `type(None)` at [points.py:392](../../../sleap_roots/points.py#L392).
+- [x] 1.2 Add `test_filter_plants_with_unexpected_ct_none_with_mismatched_shapes` in `tests/test_points.py`. Create primary_pts shape (5, 10, 2) and lateral_pts shape (3, 10, 2), call with `expected_count=None`, and assert the returned primary has shape (5, 10, 2) and the returned lateral has shape (3, 10, 2). Verifies `None` is a genuine skip (not a "match required against primary count" shortcut). **Expected failure before implementation**: same `ValueError` as 1.1.
+- [x] 1.3 Add `test_filter_plants_with_unexpected_ct_default_expected_count` in `tests/test_points.py`. Call `filter_plants_with_unexpected_ct(primary_pts, lateral_pts)` with exactly two positional args, relying on the new default, and assert pass-through. Verifies the default value binding of `None`. **Expected failure before implementation**: `TypeError` for missing positional argument `expected_count`.
+
+## 1b. Edge-case tests that lock existing numeric semantics (pin Req 2 scenarios that have no pre-existing test coverage)
+
+- [x] 1.4 Add `test_filter_plants_with_unexpected_ct_zero_count_empty_primary` in `tests/test_points.py`. Create `primary_pts = np.empty((0, 10, 2))`, `lateral_pts = np.empty((0, 10, 2))`, call `filter_plants_with_unexpected_ct(primary_pts, lateral_pts, 0)`, and assert both returned shapes are `(0, 10, 2)` (pass-through, because `round(0) == 0 == len(primary_pts)`). This pins the `expected_count=0` scenario added to Req 2. **Expected state before implementation**: test passes today (preexisting behavior). Written as a regression guard, not TDD.
+- [x] 1.5 Add `test_filter_plants_with_unexpected_ct_zero_count_nonempty_primary` in `tests/test_points.py`. Create `primary_pts = np.random.rand(3, 10, 2)`, `lateral_pts = np.random.rand(3, 10, 2)`, call with `expected_count=0`, and assert both returned arrays are shape `(0, 10, 2)` (mismatch branch). **Expected state before implementation**: passes today.
+- [x] 1.6 Add `test_filter_plants_with_unexpected_ct_half_integer_expected_count` in `tests/test_points.py`. Two assertions in one test:
+  - With `primary_pts = np.random.rand(2, 10, 2)`, `lateral_pts = np.random.rand(2, 10, 2)`, `expected_count=2.5`, assert pass-through (because `round(2.5) == 2 == len(primary_pts)` under Python banker's rounding).
+  - With `primary_pts = np.random.rand(4, 10, 2)`, `lateral_pts = np.random.rand(4, 10, 2)`, `expected_count=3.5`, assert pass-through (because `round(3.5) == 4`).
+
+  Pins the banker's-rounding rule against a future refactor that swaps `round()` for `int()` truncation or `math.floor(x + 0.5)`. **Expected state before implementation**: passes today.
+
+## 1c. Regression guard for the NaN integration path (pipeline behavior)
+
+- [x] 1.7 Add `test_multiple_dicot_pipeline_without_csv` in `tests/test_trait_pipelines.py`. Use the existing fixtures `multiple_arabidopsis_11do_primary_slp` and `multiple_arabidopsis_11do_lateral_slp` from [tests/fixtures/data.py:179-187](../../../tests/fixtures/data.py#L179-L187) — do **NOT** use the `multiple_arabidopsis_11do_csv` fixture. Call `Series.load(series_name="997_1", primary_path=..., lateral_path=...)` without `csv_path`. Instantiate `pipeline = MultipleDicotPipeline()`. Then:
+  1. Assert `np.isnan(series.expected_count)` is `True` (documents the precondition; fails loudly if `Series.expected_count` is later changed to return `None`).
+  2. Call `result = pipeline.compute_multiple_dicots_traits(series)`. Assert the call does not raise.
+  3. Assert `set(result.keys()) == {"series", "group", "qc_fail", "traits", "summary_stats"}` — the full five-key set from [trait_pipelines.py:414-420](../../../sleap_roots/trait_pipelines.py#L414-L420). Include a one-line comment in the test: `# Strict equality is intentional: new keys require an explicit spec update.` Do NOT assert the *value* of `result["group"]` — it will be the literal string `"nan"` when CSV is absent because `series.group` returns `np.nan` and [trait_pipelines.py:416](../../../sleap_roots/trait_pipelines.py#L416) coerces via `str(...)`. In contrast, `result["qc_fail"]` is stored as a raw float (no `str()` coercion) at [trait_pipelines.py:417](../../../sleap_roots/trait_pipelines.py#L417), so it will be a Python `float('nan')`, not the string `"nan"` — if you need to assert its value use `math.isnan(result["qc_fail"])`, not `result["qc_fail"] == "nan"`. Just checking key membership is the safest option and is what the spec requires.
+  4. **Because `primary_pts_expected_plant_ct` is declared `include_in_csv=False`** at [trait_pipelines.py:2647-2654](../../../sleap_roots/trait_pipelines.py#L2647-L2654) and is discarded after each frame inside `compute_multiple_dicots_traits`, the per-frame "at least one frame has plants" assertion must call the pipeline directly frame-by-frame. Write a loop:
+
+     ```python
+     max_n_instances = 0
+     for frame_idx in range(len(series)):
+         frame_traits = pipeline.compute_frame_traits(
+             pipeline.get_initial_frame_traits(series, frame_idx)
+         )
+         max_n_instances = max(
+             max_n_instances,
+             int(frame_traits["primary_pts_expected_plant_ct"].shape[0]),
+         )
+     assert max_n_instances >= 1, (
+         "Pipeline with no CSV should not strip all plants from all frames"
+     )
+     ```
+
+     Iterating over all frames (instead of hard-coding frame 0) guarantees robustness if the chosen sample's frame 0 happens to have all-NaN predictions.
+
+  **Expected state before implementation**: this test should already pass today because the NaN skip path is already wired. It is a regression guard — not TDD — for the downstream dependency that issue #126 will rely on. If it unexpectedly fails today, stop and triage before continuing.
+
+- [x] 1.8 Run `uv run pytest tests/test_points.py::test_filter_plants_with_unexpected_ct_none_expected_count tests/test_points.py::test_filter_plants_with_unexpected_ct_none_with_mismatched_shapes tests/test_points.py::test_filter_plants_with_unexpected_ct_default_expected_count -x -v`. Required outcome: **all three fail** with `ValueError`/`TypeError` as documented above. This is the TDD discipline gate for Section 2.
+- [x] 1.9 Run `uv run pytest tests/test_points.py::test_filter_plants_with_unexpected_ct_zero_count_empty_primary tests/test_points.py::test_filter_plants_with_unexpected_ct_zero_count_nonempty_primary tests/test_points.py::test_filter_plants_with_unexpected_ct_half_integer_expected_count tests/test_trait_pipelines.py::test_multiple_dicot_pipeline_without_csv -x -v`. Required outcome: **all four pass** today (these are regression guards, not failing-first TDD). If any fail, stop and investigate.
+- [x] 1.10 **File pre-existing bug as a new GitHub issue**: `tests/test_trait_pipelines.py` currently defines `test_multiple_dicot_pipeline` twice (lines 1389 and 1439). Python's module-level name collision means pytest only runs the second definition; the first is dead code. This is unrelated to issue #125 but was discovered during openspec review. File a new issue (`gh issue create`) titled "Duplicate `test_multiple_dicot_pipeline` in tests/test_trait_pipelines.py — first definition is dead code" before committing, and reference the new issue number in the commit message for task 1.7. **Recorded new issue: #154** (https://github.com/talmolab/sleap-roots/issues/154) Do **not** fix this in this PR — out of scope.
+
+## 2. Implement the minimal signature change
+
+- [x] 2.1 Edit `sleap_roots/points.py::filter_plants_with_unexpected_ct`:
+  - Ensure `Optional` is imported from `typing` (add to the existing `from typing import ...` import if missing).
+  - Change the signature to `expected_count: Optional[float] = None`.
+  - Keep the `primary_pts`/`lateral_pts` `np.ndarray` type check as the first guard.
+  - Add an early-return branch immediately after the array check: `if expected_count is None: return primary_pts, lateral_pts`. This must run **before** the `np.issubdtype(type(expected_count), np.number)` check (which would otherwise reject `None`).
+  - Leave the numeric subdtype check, the NaN skip, the round + length comparison, and the empty-array mismatch branch unchanged.
+  - Rewrite the docstring `Args:` entry for `expected_count` to read **verbatim** as the text below (prose wording may be tightened for line length by black, but the semantic content must match):
+
+    > `expected_count: Optional expected number of primary roots. If `None` or `np.nan`, no count-based filtering is applied and both input arrays are returned unchanged. `None` conceptually indicates "no expected count was configured"; `np.nan` conceptually indicates "configured but missing from metadata" (e.g. CSV entry absent). The cylinder pipeline treats both identically because it has no way to distinguish them downstream — the distinction is a deferred concern for future plate-pipeline work (issue #126). If a finite number, it is rounded via Python's built-in `round()` (banker's rounding, half-to-even: `round(2.5) == 2`, `round(3.5) == 4`); if `len(primary_pts)` does not match the rounded value, both arrays are replaced with empty `(0, n_nodes, 2)` placeholders so `MultipleDicotPipeline`'s per-series aggregation drops the frame.
+
+  - Update the `Raises:` entry to state that a `ValueError` is raised when `expected_count` is neither `None` nor a numeric type, and when `primary_pts`/`lateral_pts` are not numpy arrays.
+- [x] 2.2 Re-run `uv run pytest tests/test_points.py::test_filter_plants_with_unexpected_ct_none_expected_count tests/test_points.py::test_filter_plants_with_unexpected_ct_none_with_mismatched_shapes tests/test_points.py::test_filter_plants_with_unexpected_ct_default_expected_count -x -v`. All three new TDD tests (1.1–1.3) must now pass. Task 1.9's regression tests (1.4–1.7) must still pass.
+
+## 3. Regression, style, and validation
+
+- [x] 3.1 Run `uv run pytest tests/test_points.py -v`. Verify all tests pass, and **explicitly confirm** that the four pre-existing tests from the coverage map above still pass unchanged:
+  - `test_filter_plants_with_unexpected_ct_valid_input_matching_count`
+  - `test_filter_plants_with_unexpected_ct_valid_input_non_matching_count`
+  - `test_filter_plants_with_unexpected_ct_nan_expected_count`
+  - `test_filter_plants_with_unexpected_ct_incorrect_input_types` (specifically the string-input case at lines 763-767, which must continue to raise `ValueError` because the string still fails the numeric subdtype check).
+- [x] 3.2 Run `uv run pytest tests/test_trait_pipelines.py -v` and verify no regression in the existing `MultipleDicotPipeline` tests.
+- [x] 3.3 Run `uv run pytest tests/ -x` and verify the full suite passes.
+- [x] 3.4 Run `uv run black --check sleap_roots/points.py tests/test_points.py tests/test_trait_pipelines.py` and verify formatting is clean.
+- [x] 3.5 Run `uv run pydocstyle --convention=google sleap_roots/points.py` and verify the updated docstring passes.
+- [x] 3.6 Run `openspec validate make-expected-count-optional --strict` and verify clean.
+- [x] 3.7 **Post the scope-narrowing comment on issue #125** — this is the mechanical gate for the maintainer-authorized scope split documented in proposal.md §Why. Run:
+
+  ```bash
+  gh issue comment 125 --body "$(cat <<'EOF'
+  ## Scope split (session decision, 2026-04-15)
+
+  Per discussion with @eberrigan, this issue is being narrowed to cover **only** the `Optional[float] = None` signature change for `filter_plants_with_unexpected_ct`. The remaining acceptance criteria are transferred to #126 (`MultipleDicotPlatePipeline`):
+
+  - `count_mismatch: True` flag on mismatch → transferred to #126
+  - `count_validated: False` on the None/skip path → transferred to #126 (already covered in #126's "Expected Count Behavior (#125)" section)
+  - `count_validated: True` on the match path → transferred to #126 — **please extend #126's "Expected Count Behavior" section to cover this**
+  - `count_validated: True` on the mismatch path → transferred to #126 — **please extend #126's "Expected Count Behavior" section to cover this**
+  - Warning log on mismatch → transferred to #126
+  - "Include all detected plants on mismatch" → transferred to #126
+
+  **Reasoning**: `MultipleDicotPipeline` serves ~72-frame cylinder series where dropping a count-mismatched frame from aggregation is the right response — there are plenty of other frames and summary stats stay clean. Plates have one frame per timepoint, so "keep all plants + flag mismatch" semantics are load-bearing for plates and harmful for cylinders. Keeping the cylinder function strict and letting the plate pipeline (issue #126) choose its own strategy is cleaner than coupling two pipelines through one function's behavior.
+
+  OpenSpec proposal: `openspec/changes/make-expected-count-optional/` (PR link TBD).
+  EOF
+  )"
+  ```
+
+  Then verify the comment was posted successfully:
+
+  ```bash
+  gh issue view 125 --comments | grep -q "Scope split (session decision, 2026-04-15)" && echo "Comment posted" || { echo "COMMENT MISSING — fix before merge"; exit 1; }
+  ```
+
+  This task MUST be completed before the PR is marked ready for review. Without it, the maintainer-authorized scope narrowing has no record in the GitHub issue tracker and future readers cannot audit the decision trail.
+
+## Dependencies and sequencing
+
+- **Section 2 depends on Section 1** (TDD + regression guards): all tests in 1.1–1.7 must be written before any edit in Section 2.
+- **Task 1.8** is the TDD discipline gate for the `None` contract tests (1.1–1.3). They MUST fail before implementation with the documented `ValueError`/`TypeError` patterns; anything else means the tests don't exercise the correct pre-change contract and must be fixed before proceeding.
+- **Task 1.9** verifies the regression-guard tests (1.4–1.7) pass today. If any fail today, stop and triage — they are expressing pre-existing behavior that the implementation must not break.
+- **Task 1.10** (file the duplicate-function-name issue) must complete before any commit in the `feature/optional-expected-count-125` branch so the commit message can reference the new issue number.
+- Section 3 depends on Section 2.
+- Within each subsection, individual tasks are order-independent.
+
+### Commit safety note
+
+Sections 1 and 2 leave the test suite **red** between the `None`-contract tests landing (1.1–1.3) and the implementation landing (2.1). This is tolerable on a local feature branch but will show red CI on every intermediate push. Recommended workflow: develop sections 1 and 2 locally, then push them as a single squashed commit OR as consecutive commits within a single push to minimize the sustained red CI window. The repo's `.github/workflows/ci.yml` does not enforce green-on-every-commit, so this is cosmetic, not blocking.
+
+## Notes
+
+- The `MultipleDicotPipeline` TraitDef wiring at [trait_pipelines.py:2633-2645](../../../sleap_roots/trait_pipelines.py#L2633-L2645) is **not** touched by this change. No TraitDef rename, no new TraitDef, no output-shape change.
+- No changes to `Series.expected_count` — it continues to return `np.nan` for missing CSV. If issue #126 later needs `Series.expected_count` to return `None`, that will be a separate proposal.
+- No changes to existing tests' assertions about the `(0, n_nodes, 2)` mismatch output — cylinder pipeline semantics remain strict-drop.
+- The duplicate `test_multiple_dicot_pipeline` function name at [tests/test_trait_pipelines.py:1389](../../../tests/test_trait_pipelines.py#L1389) and [:1439](../../../tests/test_trait_pipelines.py#L1439) is a pre-existing bug surfaced by openspec review. It is filed as a separate issue under task 1.10 and NOT fixed in this PR.

--- a/sleap_roots/points.py
+++ b/sleap_roots/points.py
@@ -362,33 +362,55 @@ def filter_roots_with_nans(pts: np.ndarray) -> np.ndarray:
 
 
 def filter_plants_with_unexpected_ct(
-    primary_pts: np.ndarray, lateral_pts: np.ndarray, expected_count: float
+    primary_pts: np.ndarray,
+    lateral_pts: np.ndarray,
+    expected_count: Optional[float] = None,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Filter out primary and lateral roots with an unexpected number of plants.
 
     Args:
         primary_pts: A numpy array of primary root points with shape
-            (instances, nodes, 2), where 'instances' is the number of primary roots,
-            'nodes' is the number of points in each root, and '2' corresponds to the x and y
-            coordinates.
-        lateral_pts: A numpy array of lateral root points with a shape similar
-            to primary_pts, representing the lateral roots.
-        expected_count: The expected number of primary roots as a float or NaN. If NaN,
-            no filtering is applied based on count. If a number, it will be rounded to
-            the nearest integer for comparison.
+            (instances, nodes, 2), where 'instances' is the number of primary
+            roots, 'nodes' is the number of points in each root, and '2'
+            corresponds to the x and y coordinates.
+        lateral_pts: A numpy array of lateral root points with a shape similar to
+            primary_pts, representing the lateral roots.
+        expected_count: Optional expected number of primary roots. If ``None`` or
+            ``np.nan``, no count-based filtering is applied and both input arrays
+            are returned unchanged. ``None`` conceptually indicates "no expected
+            count was configured"; ``np.nan`` conceptually indicates "configured
+            but missing from metadata" (e.g. CSV entry absent). The cylinder
+            pipeline treats both identically because it has no way to distinguish
+            them downstream — the distinction is a deferred concern for future
+            plate-pipeline work (issue #126). If a finite number, it is rounded
+            via Python's built-in ``round()`` (banker's rounding, half-to-even:
+            ``round(2.5) == 2``, ``round(3.5) == 4``); if ``len(primary_pts)``
+            does not match the rounded value, both arrays are replaced with empty
+            ``(0, n_nodes, 2)`` placeholders so ``MultipleDicotPipeline``'s
+            per-series aggregation drops the frame. The value ``0`` is a valid
+            finite ``expected_count``: it takes the pass-through branch if
+            ``primary_pts`` is also empty, and the mismatch branch otherwise.
+            Defaults to ``None``.
 
     Returns:
-        A tuple containing the filtered primary and lateral root points arrays. If the
-        input types are incorrect, the function will raise a ValueError.
+        A tuple containing the filtered primary and lateral root points arrays.
 
     Raises:
-        ValueError: If input types are incorrect.
+        ValueError: If ``primary_pts`` or ``lateral_pts`` are not numpy arrays,
+            or if ``expected_count`` is neither ``None`` nor a numeric type.
     """
     # Type checking
     if not isinstance(primary_pts, np.ndarray) or not isinstance(
         lateral_pts, np.ndarray
     ):
         raise ValueError("primary_pts and lateral_pts must be numpy arrays.")
+
+    # None means "no expected count was configured" — skip filtering entirely.
+    # This branch runs before the numeric subdtype check below, which would
+    # otherwise reject type(None).
+    if expected_count is None:
+        return primary_pts, lateral_pts
+
     if not np.issubdtype(type(expected_count), np.number):
         raise ValueError("expected_count must be a numeric type.")
 

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -767,6 +767,120 @@ def test_filter_plants_with_unexpected_ct_incorrect_input_types():
         filter_plants_with_unexpected_ct(primary_pts, lateral_pts, expected_count)
 
 
+def test_filter_plants_with_unexpected_ct_none_expected_count():
+    """`None` as expected_count skips filtering and returns inputs unchanged."""
+    primary_pts = np.random.rand(5, 10, 2)
+    lateral_pts = np.random.rand(5, 10, 2)
+    filtered_primary, filtered_lateral = filter_plants_with_unexpected_ct(
+        primary_pts, lateral_pts, expected_count=None
+    )
+    assert np.array_equal(filtered_primary, primary_pts)
+    assert np.array_equal(filtered_lateral, lateral_pts)
+
+
+def test_filter_plants_with_unexpected_ct_none_with_mismatched_shapes():
+    """`None` is a genuine skip, not a stealth match-against-primary-count path."""
+    primary_pts = np.random.rand(5, 10, 2)
+    lateral_pts = np.random.rand(3, 10, 2)
+    filtered_primary, filtered_lateral = filter_plants_with_unexpected_ct(
+        primary_pts, lateral_pts, expected_count=None
+    )
+    assert filtered_primary.shape == (5, 10, 2)
+    assert filtered_lateral.shape == (3, 10, 2)
+    assert np.array_equal(filtered_primary, primary_pts)
+    assert np.array_equal(filtered_lateral, lateral_pts)
+
+
+def test_filter_plants_with_unexpected_ct_default_expected_count():
+    """Omitting expected_count relies on the new default of `None` and skips filtering."""
+    primary_pts = np.random.rand(5, 10, 2)
+    lateral_pts = np.random.rand(5, 10, 2)
+    filtered_primary, filtered_lateral = filter_plants_with_unexpected_ct(
+        primary_pts, lateral_pts
+    )
+    assert np.array_equal(filtered_primary, primary_pts)
+    assert np.array_equal(filtered_lateral, lateral_pts)
+
+
+def test_filter_plants_with_unexpected_ct_zero_count_empty_primary():
+    """expected_count=0 with empty primary_pts passes through (round(0)==0==len)."""
+    primary_pts = np.empty((0, 10, 2))
+    lateral_pts = np.empty((0, 10, 2))
+    filtered_primary, filtered_lateral = filter_plants_with_unexpected_ct(
+        primary_pts, lateral_pts, 0
+    )
+    assert filtered_primary.shape == (0, 10, 2)
+    assert filtered_lateral.shape == (0, 10, 2)
+
+
+def test_filter_plants_with_unexpected_ct_zero_count_nonempty_primary():
+    """expected_count=0 with 3 primary instances takes the mismatch branch."""
+    primary_pts = np.random.rand(3, 10, 2)
+    lateral_pts = np.random.rand(3, 10, 2)
+    filtered_primary, filtered_lateral = filter_plants_with_unexpected_ct(
+        primary_pts, lateral_pts, 0
+    )
+    assert filtered_primary.shape == (0, 10, 2)
+    assert filtered_lateral.shape == (0, 10, 2)
+
+
+def test_filter_plants_with_unexpected_ct_half_integer_expected_count():
+    """Pin Python banker's rounding: round(2.5)==2, round(3.5)==4, round(4.5)==4.
+
+    The third case is the one that actually distinguishes banker's rounding
+    (half-to-even) from plain `int(x + 0.5)` rounding: for `expected_count=4.5`
+    banker's gives 4 (pass-through against 4 primaries), but plain rounding
+    would give 5 (mismatch → empty arrays). A future refactor that swapped
+    `round()` for `int(x + 0.5)` or `math.ceil` would be caught by the third
+    assertion block below.
+    """
+    # round(2.5) == 2 — symmetric case
+    primary_pts_2 = np.random.rand(2, 10, 2)
+    lateral_pts_2 = np.random.rand(2, 10, 2)
+    filtered_primary_2, filtered_lateral_2 = filter_plants_with_unexpected_ct(
+        primary_pts_2, lateral_pts_2, 2.5
+    )
+    assert np.array_equal(filtered_primary_2, primary_pts_2)
+    assert np.array_equal(filtered_lateral_2, lateral_pts_2)
+
+    # round(3.5) == 4 — symmetric case
+    primary_pts_4 = np.random.rand(4, 10, 2)
+    lateral_pts_4 = np.random.rand(4, 10, 2)
+    filtered_primary_4, filtered_lateral_4 = filter_plants_with_unexpected_ct(
+        primary_pts_4, lateral_pts_4, 3.5
+    )
+    assert np.array_equal(filtered_primary_4, primary_pts_4)
+    assert np.array_equal(filtered_lateral_4, lateral_pts_4)
+
+    # round(4.5) == 4 (banker's half-to-even) — THIS is the asymmetric case.
+    # Plain int(4.5 + 0.5) would give 5, which would mismatch len=4 and
+    # return empty arrays. By asserting pass-through here, we pin banker's
+    # rounding specifically.
+    primary_pts_4b = np.random.rand(4, 10, 2)
+    lateral_pts_4b = np.random.rand(4, 10, 2)
+    filtered_primary_4b, filtered_lateral_4b = filter_plants_with_unexpected_ct(
+        primary_pts_4b, lateral_pts_4b, 4.5
+    )
+    assert np.array_equal(filtered_primary_4b, primary_pts_4b)
+    assert np.array_equal(filtered_lateral_4b, lateral_pts_4b)
+
+
+def test_filter_plants_with_unexpected_ct_bool_expected_count_raises():
+    """expected_count=False raises ValueError (bool is not a numpy numeric subtype).
+
+    Pins NumPy 2.x behavior where `np.issubdtype(type(False), np.number)` is
+    False, so booleans are rejected rather than silently treated as 0. Older
+    NumPy versions treated bool as a numeric subtype, which would have created
+    a silent-zero footgun — this test locks in the safer current behavior.
+    """
+    primary_pts = np.random.rand(5, 10, 2)
+    lateral_pts = np.random.rand(5, 10, 2)
+    with pytest.raises(ValueError):
+        filter_plants_with_unexpected_ct(primary_pts, lateral_pts, False)
+    with pytest.raises(ValueError):
+        filter_plants_with_unexpected_ct(primary_pts, lateral_pts, True)
+
+
 def test_filter_primary_roots_with_unexpected_ct_valid_inputs():
     """Test with valid input types to check expected output shape."""
     primary_pts = np.random.rand(5, 10, 2)

--- a/tests/test_trait_pipelines.py
+++ b/tests/test_trait_pipelines.py
@@ -1829,6 +1829,88 @@ def test_multiple_dicot_pipeline(
     pd.testing.assert_frame_equal(computed_group_batch_traits, group_batch_df_fixture)
 
 
+def test_multiple_dicot_pipeline_without_csv(
+    multiple_arabidopsis_11do_primary_slp,
+    multiple_arabidopsis_11do_lateral_slp,
+):
+    """MultipleDicotPipeline runs end-to-end when Series is loaded without csv_path.
+
+    Regression guard for issue #125: Series.expected_count returns np.nan when the
+    CSV is absent, and filter_plants_with_unexpected_ct must treat NaN as "skip
+    filter" rather than stripping all plants. This test protects the downstream
+    dependency that issue #126 will rely on.
+    """
+    series = Series.load(
+        series_name="997_1",
+        primary_path=multiple_arabidopsis_11do_primary_slp,
+        lateral_path=multiple_arabidopsis_11do_lateral_slp,
+    )
+    assert np.isnan(series.expected_count)
+
+    pipeline = MultipleDicotPipeline()
+    result = pipeline.compute_multiple_dicots_traits(series)
+
+    # Strict equality is intentional: new keys require an explicit spec update.
+    assert set(result.keys()) == {
+        "series",
+        "group",
+        "qc_fail",
+        "traits",
+        "summary_stats",
+    }
+
+    # `primary_pts_expected_plant_ct` is an `include_in_csv=False` per-frame
+    # TraitDef that is discarded after each frame inside
+    # `compute_multiple_dicots_traits`, so we invoke the pipeline directly
+    # frame-by-frame to verify the NaN path did not strip all plants. Iterating
+    # over all frames (rather than hard-coding frame 0) avoids flakiness from
+    # per-sample labeling drift where a specific frame has all-NaN predictions.
+    max_n_instances = 0
+    for frame_idx in range(len(series)):
+        frame_traits = pipeline.compute_frame_traits(
+            pipeline.get_initial_frame_traits(series, frame_idx)
+        )
+        max_n_instances = max(
+            max_n_instances,
+            int(frame_traits["primary_pts_expected_plant_ct"].shape[0]),
+        )
+    assert (
+        max_n_instances >= 1
+    ), "Pipeline with no CSV should not strip all plants from all frames"
+
+
+def test_multiple_dicot_pipeline_none_expected_plant_ct_through_trait_dag():
+    """Python `None` as expected_plant_ct flows through MultipleDicotPipeline's TraitDef DAG.
+
+    The existing `test_multiple_dicot_pipeline_without_csv` exercises the NaN
+    path via `Series.expected_count`. This test exercises the literal Python
+    `None` path directly through `compute_frame_traits` by constructing an
+    initial-traits dict with `expected_plant_ct=None`. Issue #126
+    (`MultipleDicotPlatePipeline`) will be the first real consumer of this
+    path; pinning it here prevents a regression before it lands.
+    """
+    primary_pts = np.random.rand(2, 6, 2)
+    lateral_pts = np.random.rand(3, 6, 2)
+
+    pipeline = MultipleDicotPipeline()
+    initial_frame_traits = {
+        "primary_pts": primary_pts,
+        "lateral_pts": lateral_pts,
+        "expected_plant_ct": None,
+    }
+    frame_traits = pipeline.compute_frame_traits(initial_frame_traits)
+
+    # With `None`, the count filter must pass plant points through unchanged.
+    # Both arrays should retain their input instance count.
+    assert frame_traits["primary_pts_expected_plant_ct"].shape[0] == 2
+    assert frame_traits["lateral_pts_expected_plant_ct"].shape[0] == 3
+
+    # And the downstream plant-association TraitDef must run without error
+    # on the `None`-path output.
+    assert "plant_associations_dict" in frame_traits
+    assert isinstance(frame_traits["plant_associations_dict"], dict)
+
+
 def test_primary_root_pipeline(
     canola_folder,
     canola_traits_csv,


### PR DESCRIPTION
## Summary

- Make `expected_count` parameter `Optional[float] = None` in `filter_plants_with_unexpected_ct()` ([points.py:364](sleap_roots/points.py#L364))
- When `None` or `NaN`: skip count-based filtering, return both arrays unchanged
- When numeric match: pass through (unchanged)
- When numeric mismatch: return empty `(0, n_nodes, 2)` arrays (unchanged — `MultipleDicotPipeline` relies on this for frame-level drop-on-mismatch aggregation)
- No changes to `Series.expected_count`, `MultipleDicotPipeline`, or CSV output

## Motivation

Closes #125 (narrowed scope — see [scope split comment](https://github.com/talmolab/sleap-roots/issues/125#issuecomment-4254953940)). The `count_mismatch`/`count_validated` flagging and "include all plants on mismatch" acceptance criteria are transferred to #126 (`MultipleDicotPlatePipeline`) per maintainer decision.

Cleans up the API contract so #126 can call `filter_plants_with_unexpected_ct(..., expected_count=None)` without working around a `ValueError`.

## Test plan

- [x] 3 TDD unit tests for None contract (None, None+mismatched shapes, default arg omission)
- [x] 3 regression guard unit tests (zero count empty/non-empty, half-integer banker's rounding with asymmetric case pinning `round(4.5)==4`)
- [x] 1 `bool` rejection regression test (pins NumPy 2.x behavior where `np.issubdtype(type(False), np.number)` is False)
- [x] 1 integration test: `MultipleDicotPipeline` on arabidopsis sample loaded without CSV — verifies NaN path doesn't strip plants, uses per-frame `pipeline.compute_frame_traits(pipeline.get_initial_frame_traits(series, frame_idx))` loop
- [x] 1 pipeline-level None test: direct `compute_frame_traits` with `expected_plant_ct=None` through TraitDef DAG — pins the contract #126 will inherit
- [x] Full suite: 418 passed (including benchmarks)
- [x] Black, pydocstyle, openspec validate --strict: all clean

## OpenSpec

- Proposal: [`openspec/changes/make-expected-count-optional/`](openspec/changes/make-expected-count-optional/)
- New capability spec: `multiple-dicot-pipeline` (3 requirements, 11 scenarios)
- Reviewed by 5-subagent team (2 passes) — all blocking findings resolved

## Related

- Filed #154 (pre-existing duplicate `test_multiple_dicot_pipeline` function — surfaced during review, NOT fixed here)
- Dependabot vulnerabilities (#153) are pre-existing and unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)