### PR TITLE
feat: TrackedTipPipeline for tracked-tip kinematic substrate (#129)

### DIFF
--- a/.claude/commands/changelog.md
+++ b/.claude/commands/changelog.md
@@ -1,6 +1,6 @@
 # Update Changelog
 
-Maintain CHANGELOG.md following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
+Maintain docs/changelog.md following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## Quick Commands
 
@@ -26,7 +26,7 @@ python -c "import sleap_roots; print(sleap_roots.__version__)"
 
 ## Changelog Format
 
-The CHANGELOG.md follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) principles:
+The docs/changelog.md follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) principles:
 
 - **Guiding Principle**: Changelogs are for humans, not machines
 - **Latest First**: Most recent version at the top
@@ -121,7 +121,7 @@ Group commits by category:
 - **Fixed**: Bug fixes, error handling improvements
 - **Security**: Security patches, data handling fixes
 
-### Step 3: Update CHANGELOG.md
+### Step 3: Update docs/changelog.md
 
 Add changes to the `[Unreleased]` section:
 
@@ -358,9 +358,9 @@ When releasing:
 
 ```bash
 # Update version in sleap_roots/__init__.py
-# Update CHANGELOG.md
+# Update docs/changelog.md
 # Commit changes
-git add sleap_roots/__init__.py CHANGELOG.md
+git add sleap_roots/__init__.py docs/changelog.md
 git commit -m "chore: bump version to 0.2.0"
 
 # Tag release

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `TrackedTipPipeline` — root-agnostic pipeline that consumes SLEAP-tracked `.slp` predictions and emits per-track tip-trajectory data plus a minimum-viable substrate of per-track geometric scalars (`tip_trajectory_length`, `tip_displacement_net`, `tracking_coverage`, `n_frames_tracked`, `n_frames_total`). Substrate-only by design; velocity / curvature / circumnutation traits live in separate downstream pipelines that reuse this substrate. (#129, Workstream 2 of the 2026-04-23 timelapse design)
+- `Series.get_tracked_tips(root_type=None)` — long-format DataFrame of per-track tip rows (`track_id, frame, tip_x, tip_y`), sorted by `(track_id, frame)`. Supports single-node and multi-node skeletons via the `[-1]` skeleton convention.
+- `validate_tracked_slp(slp_path)` and `validate_series_for_tracked_tip(series, root_type=None)` module-level helpers in `sleap_roots.series` for input precondition checks.
+- New `notebooks/TrackedTipPipeline_Mermaid_Graph.md` — DAG visualization for the new pipeline.
+- New test fixture `tests/data/circumnutation_plate/` — real tracked .slp from the circumnutation source data (184 KB, 311 frames, 6 tracks, single-node skeleton) plus synthesized plate-level metadata CSV and per-#168-template README.
 - Comprehensive MkDocs documentation site with Material theme
 - Auto-generated API reference from docstrings
 - User guides for all pipeline types (7 pipelines)
@@ -17,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cookbook with code recipes (filtering, custom traits, batch optimization, exporting)
 - Troubleshooting guide with common issues and solutions
 - uv package manager support with PEP 735 dependency groups
+
+### Internal
+- Started per-pipeline-module pattern: `TrackedTipPipeline` lives in `sleap_roots/tracked_tip_pipeline.py` instead of being appended to the existing 3763-line `trait_pipelines.py` megafile. Splitting the existing 8 pipelines is tracked in #189.
 
 ### Changed
 - Updated installation documentation with uv best practices

--- a/docs/superpowers/specs/2026-04-23-timelapse-diff-and-tip-kinematics-design.md
+++ b/docs/superpowers/specs/2026-04-23-timelapse-diff-and-tip-kinematics-design.md
@@ -53,9 +53,9 @@ Root-agnostic pipeline consuming a **tracked** `.slp` file. Emits per-track tip 
 
 **Module placement:**
 
-- `sleap_roots/tracked_tip_pipeline.py` (NEW FILE) — `TrackedTipPipeline` class. Starts the per-pipeline-module pattern. Existing `trait_pipelines.py` megafile (3763 lines, 8 pipelines) split tracked in #189.
-- `sleap_roots/tip_kinematics.py` (NEW FILE) — pure trait functions parallel to `sleap_roots/lengths.py` and `sleap_roots/angle.py`.
+- `sleap_roots/tracked_tip_pipeline.py` (NEW FILE) — `TrackedTipPipeline` class with its inline `TraitDef` list. Starts the per-pipeline-module pattern. Existing `trait_pipelines.py` megafile (3763 lines, 8 pipelines) split tracked in #189.
 - `sleap_roots/series.py` (EXTEND) — new `Series.get_tracked_tips(root_type=None)` method + module-level validation helpers (`validate_tracked_slp`, `validate_series_for_tracked_tip`).
+- **NO new trait module** — the pipeline reuses `sleap_roots.lengths.get_root_lengths` and `sleap_roots.bases.get_base_tip_dist` directly as TraitDef functions via DAG composition. The DAG provides the per-track input slicing (`track_first_xy`, `track_last_xy`); the existing tested functions provide the computation. See "DAG-A — TraitDef topology" below.
 
 **Inputs:**
 
@@ -99,56 +99,83 @@ Returns a long-format `pd.DataFrame` with columns `track_id, frame, tip_x, tip_y
 
 - Auto-detects `root_type` from whichever of `primary_path` / `lateral_path` / `crown_path` is populated; raises `ValueError` if zero or >1 are populated and `root_type` is `None`.
 - **Iterates per-instance, NOT per-frame-stack** — tracker output does NOT preserve positional ordering across frames. Verified on the fixture: frame 0 instances are ordered `[track_0, 1, 2, 3, 4, 5]` but frame 1 is `[track_0, 3, 4, 2, 1, 5]`. Implementation reads `inst.track.name` per instance and `inst.numpy()[-1]` for the tip coordinate.
+- **Output is sorted by `(track_id, frame)`** — REQUIRED so that `groupby('track_id')` produces frame-sorted `xy` arrays, making `xy[0]` the first-tracked-frame tip and `xy[-1]` the last-tracked-frame tip. Downstream `tip_displacement_net` correctness depends on this. Implementation: `df.sort_values(['track_id', 'frame']).reset_index(drop=True)` before returning.
 - Untracked instances (`inst.track is None` or `inst.track.name` falsy) trip `ValueError` with the sleap.ai/tracking pointer.
 
-**Tip-kinematics trait functions** (`sleap_roots/tip_kinematics.py`, NEW MODULE — thin wrappers around existing trait functions):
+**Trait functions — pure DAG-A composition (no new trait module):**
 
-Pure functions on `(N, 2)` xy arrays. The pipeline calls these in its `TraitDef` DAG. **DRY-driven: the actual numpy computation lives in `sleap_roots/lengths.py` and `sleap_roots/bases.py` already.** This new module exists to (a) document tip-trajectory-specific edge cases and (b) provide a stable import path for future tip-trajectory-aware pipelines.
+The pipeline reuses existing tested trait functions DIRECTLY as TraitDef `fn` values. The DAG provides per-track input slicing (`track_first_xy`, `track_last_xy`) so existing `(2,)`-and-`(2,)` and `(N, 2)` functions plug in unchanged.
 
-| Function | Computation source | Single-frame behavior | Units family |
-|---|---|---|---|
-| `tip_trajectory_length(xy)` | Delegates to [`lengths.get_root_lengths`](sleap_roots/lengths.py#L56) (cumulative arclength via `np.diff` + `np.linalg.norm` + `np.nansum`). Wrapper special-cases single-frame to return `0.0` instead of NaN (existing function's vacuous-truth NaN behavior on empty segments). | `0.0` (no segments) | lengths |
-| `tip_displacement_net(xy)` | Delegates to [`bases.get_base_tip_dist`](sleap_roots/bases.py#L34) (Euclidean via `np.linalg.norm`). Pass `xy[0]` as base, `xy[-1]` as tip. | `0.0` (xy[0] == xy[-1] — natural, no special-case) | lengths |
-| `tracking_coverage(n_tracked, n_total)` | Trivial division — no existing utility. ~3 lines. | well-defined for `n_tracked >= 1` | ratios |
+| Trait | TraitDef `fn` | `input_traits` | Single-frame behavior | Units family |
+|---|---|---|---|---|
+| `tip_trajectory_length` | [`lengths.get_root_lengths`](sleap_roots/lengths.py#L56) (used directly — no wrapper) | `["track_xy"]` | `NaN` (existing function returns NaN on empty-segments via vacuous-truth NaN guard; we accept this as the codebase's NaN-as-undefined convention) | lengths |
+| `tip_displacement_net` | [`bases.get_base_tip_dist`](sleap_roots/bases.py#L34) (used directly — no wrapper) | `["track_first_xy", "track_last_xy"]` | `0.0` natural (xy[0] == xy[-1] for single-frame; no special-case) | lengths |
+| `tracking_coverage` | inline lambda `lambda nt, ntot: nt/ntot if ntot else np.nan` | `["n_frames_tracked", "n_frames_total"]` | well-defined for `n_tracked >= 1` | ratios |
 
-Single-frame tracks emit `length=0.0, displacement=0.0` — mathematically correct (no segments → no length); no NaN special-casing in the pipeline output. Downstream filtering on `n_frames_tracked == 1` is the user's option.
+Single-frame edge case asymmetry is **deliberate and documented**: `tip_displacement_net = 0.0` (geometric — same point twice), `tip_trajectory_length = NaN` (codebase convention — undefined). Users who want either filtered or coerced apply `fillna(0.0)` post-hoc; users who want only "real trajectories" filter on `n_frames_tracked > 1`. Both `tracking_coverage` and `n_frames_tracked` are emitted on every row, so single-frame degeneracy is explicit and filterable.
 
-**Implementation sketch** (~30 lines total — nearly all delegation):
+**DAG-A — TraitDef topology:**
+
+Pipeline uses the existing `TraitDef` graph plumbing (per `DicotPipeline` and friends). The input is the long-format `tracked_tips_df` (sorted by `(track_id, frame)`); the iteration unit is `track_id`, not `frame`. Pipeline iterates `for track_id, group in df.groupby('track_id'):` and runs the full DAG once per track.
+
+Concrete `TrackedTipPipeline.traits` list:
 
 ```python
 from sleap_roots.lengths import get_root_lengths
 from sleap_roots.bases import get_base_tip_dist
 
-def tip_trajectory_length(xy: np.ndarray) -> float:
-    if xy.shape[0] == 0: return np.nan
-    if xy.shape[0] == 1: return 0.0
-    return float(get_root_lengths(xy))
+traits = [
+    # Per-track inputs (computed in compute_tracked_tip_traits prep loop):
+    TraitDef(name="track_xy", ...),               # Nx2 frame-sorted trajectory
+    TraitDef(name="n_frames_tracked", ...),
+    TraitDef(name="n_frames_total", ...),
 
-def tip_displacement_net(xy: np.ndarray) -> float:
-    if xy.shape[0] == 0: return np.nan
-    return float(get_base_tip_dist(xy[0], xy[-1]))
+    # Per-track slicing (one-line lambdas; DAG provides per-track-frame
+    # endpoints so the existing distance function below plugs in unchanged):
+    TraitDef(name="track_first_xy",
+             fn=lambda xy: xy[0],
+             input_traits=["track_xy"], scalar=False),
+    TraitDef(name="track_last_xy",
+             fn=lambda xy: xy[-1],
+             input_traits=["track_xy"], scalar=False),
 
-def tracking_coverage(n_frames_tracked: int, n_frames_total: int) -> float:
-    if n_frames_total == 0: return np.nan
-    return n_frames_tracked / n_frames_total
+    # Trait scalars — existing trait functions used DIRECTLY via DAG composition:
+    TraitDef(name="tip_displacement_net",
+             fn=get_base_tip_dist,                # ← from bases.py, no wrapper
+             input_traits=["track_first_xy", "track_last_xy"],
+             scalar=True, include_in_csv=True),
+
+    TraitDef(name="tip_trajectory_length",
+             fn=get_root_lengths,                 # ← from lengths.py, no wrapper
+             input_traits=["track_xy"],
+             scalar=True, include_in_csv=True),
+
+    TraitDef(name="tracking_coverage",
+             fn=lambda nt, ntot: nt / ntot if ntot else np.nan,
+             input_traits=["n_frames_tracked", "n_frames_total"],
+             scalar=True, include_in_csv=True),
+]
 ```
 
-Existing functions in `lengths.py` / `bases.py` have full test coverage and known NaN semantics. The wrappers' tests just cover the tip-trajectory-specific edge cases (single-frame zeros, empty input).
-
-**DAG-A — TraitDef topology:**
-
-Pipeline uses the existing `TraitDef` graph plumbing (per `DicotPipeline` and friends), but the input is the long-format `tracked_tips_df` and the iteration unit is `track_id`, not `frame`:
+DAG topology:
 
 ```
-tracked_tips_df  (input from series.get_tracked_tips())
+tracked_tips_df (sorted by (track_id, frame))
         │
-        │ groupby(track_id) → track_xy (Nx2)
+        │ groupby(track_id)
         ▼
-        ├─→ tip_trajectory_length(track_xy)
-        ├─→ tip_displacement_net(track_xy)
-        ├─→ tracking_coverage(n_frames_tracked, n_frames_total)
-        ├─→ n_frames_tracked
-        └─→ n_frames_total
+        ├──> track_xy (Nx2 frame-sorted)
+        │       │
+        │       ├──> track_first_xy = xy[0]   ──┐
+        │       ├──> track_last_xy  = xy[-1]  ──┴──> tip_displacement_net
+        │       │                                    (= get_base_tip_dist)
+        │       │
+        │       └──> tip_trajectory_length
+        │            (= get_root_lengths)
+        │
+        ├──> n_frames_tracked  ──┐
+        └──> n_frames_total   ──┴──> tracking_coverage
+                                     (= nt / ntot)
                 │
                 ▼
         per-track summary row
@@ -185,7 +212,7 @@ tracked_tips_df  (input from series.get_tracked_tips())
 **Edge cases** (deliberate behavior, tested):
 
 - **Zero tracked instances anywhere** — pipeline emits empty `tracks` and `trajectories` arrays / empty CSVs, no crash.
-- **Single-frame track** — `length=0.0, displacement=0.0`, `n_frames_tracked=1`, `tracking_coverage > 0`, no NaN.
+- **Single-frame track** — `tip_displacement_net=0.0` (natural, xy[0]==xy[-1]), `tip_trajectory_length=NaN` (codebase convention from `get_root_lengths`'s NaN-on-empty-segments guard — accepted as the trade-off for using the existing function directly via DAG-A; no wrapper), `n_frames_tracked=1`, `tracking_coverage > 0`. Documented asymmetry; users `fillna(0.0)` or filter on `n_frames_tracked > 1`.
 - **Partial tracking (gaps)** — compute on available window; `tracking_coverage < 1.0`.
 - **Track-fragment / re-ID** — trust the tracker. If one physical tip becomes two `track_id`s in the source, two summary rows appear. **Documented assumption: input `.slp` is proofread.**
 - **Multiple root paths populated** — `ValueError` requesting explicit `root_type`.
@@ -365,8 +392,8 @@ Per-workstream fixture plan. PR #165 shipped synthetic-only with real fixtures d
 
 Synthetic coverage (primary test surface):
 
-- Pure trait functions in `sleap_roots/tip_kinematics.py` against known `(N, 2)` arrays — exact-value assertions on multi-segment trajectories, single-frame degenerate case (`length=0.0, displacement=0.0`), known geometric shapes (square, straight line).
-- `Series.get_tracked_tips` accessor on synthetic `.slp` files with `sio.Track` objects attached to `sio.Instance` via `from_numpy(..., track=...)` — exercises root-type auto-detection, multiple-paths-populated `ValueError`, untracked-instance `ValueError`, single-node and multi-node skeleton paths.
+- Existing trait functions (`lengths.get_root_lengths`, `bases.get_base_tip_dist`) already have full unit tests in the repo — no new pure-function tests needed for them. The new tests in this PR cover the **pipeline-level composition**: that the DAG correctly slices `track_first_xy` / `track_last_xy`, passes them to `get_base_tip_dist`, and routes `track_xy` to `get_root_lengths`. Exact-value assertions on multi-segment trajectories (e.g. straight line of known length, right-angle path with known total + known displacement), single-frame degenerate case (`tip_displacement_net=0.0`, `tip_trajectory_length=NaN`), and the inline `tracking_coverage` lambda's NaN-on-zero-total guard.
+- `Series.get_tracked_tips` accessor on synthetic `.slp` files with `sio.Track` objects attached to `sio.Instance` via `from_numpy(..., track=...)` — exercises root-type auto-detection, multiple-paths-populated `ValueError`, untracked-instance `ValueError`, single-node and multi-node skeleton paths, **frame-sorted output ordering** (regression-test the sort that `tip_displacement_net` correctness depends on).
 - Pipeline DAG, CSV/JSON emission, batch concat, `emit_trajectories=False` skip path, empty-input / single-frame / short-track edge cases — all via synthetic `.slp` files.
 
 Real-fixture coverage (committed in the PR):

--- a/docs/superpowers/specs/2026-04-23-timelapse-diff-and-tip-kinematics-design.md
+++ b/docs/superpowers/specs/2026-04-23-timelapse-diff-and-tip-kinematics-design.md
@@ -1,9 +1,9 @@
 # Design: Timelapse diffs, tracked-tip kinematics, and metadata generalization
 
-**Date**: 2026-04-23
-**Related issues**: #112 (close as obsolete), #129 (refresh), #163 (broaden), #159 (related), #169 (Workstream 1 metadata layer — implemented in PR #171), #170 (Workstream 3 TimeDiffPipeline)
-**Depends on**: PR #165 (MultipleDicotPlatePipeline) — merged 2026-04-21
-**Status**: Brainstorm complete, spec drafted. Circumnutation trait set deferred to a follow-up design once the maintainer has assembled a literature reference for method selection.
+**Date**: 2026-04-23 (updated 2026-05-06 — Workstream 2 brainstorm complete)
+**Related issues**: #112 (close as obsolete), #129 (refresh), #163 (broaden), #159 (related), #169 (Workstream 1 metadata layer — implemented in PR #171), #170 (Workstream 3 TimeDiffPipeline), #186 (per-frame metadata accessor — Workstream 2 follow-up), #187 (preprocessing helpers — Workstream 2 follow-up), #188 (generic META→CSV converter — Workstream 2 follow-up), #189 (split `trait_pipelines.py` megafile — triggered by #129)
+**Depends on**: PR #165 (MultipleDicotPlatePipeline) — merged 2026-04-21; PR #171 (Workstream 1 metadata layer) — merged 2026-05-06
+**Status**: Workstream 1 shipped (PR #171). Workstream 2 brainstorm complete (2026-05-06); ready for OpenSpec proposal + TDD implementation. Circumnutation trait set deferred to a follow-up design once the maintainer has assembled a literature reference for method selection.
 
 ## Summary
 
@@ -47,53 +47,129 @@ Small extension of the existing metadata pattern (`Series.expected_count`, `.gro
 
 ### Workstream 2 — `TrackedTipPipeline` (refresh of #129)
 
-Root-agnostic pipeline consuming a **tracked** `.slp` file. Emits per-track tip trajectories + per-track growth-kinematic scalars. Scope matches the original #129 (kinematics only). Circumnutation-specific traits (period, amplitude, angular velocity, rotation direction, etc.) are deferred to a separate follow-up that will be designed against published literature — see "Deferred: circumnutation trait set" below.
+Root-agnostic pipeline consuming a **tracked** `.slp` file. Emits per-track tip trajectories + a **minimum-viable substrate** of per-track geometric scalars. **TrackedTipPipeline's scope is the substrate, period.** Velocity, curvature, smoothness, tortuosity, direction-changes, circumnutation traits — none of these belong in TrackedTipPipeline now or in the future. They live in **separate downstream pipelines** (e.g. `CircumnutationPipeline`, future growth-rate / gravitropism pipelines) that REUSE this pipeline's `Series.get_tracked_tips` accessor and trajectory-row output as their input substrate. Keeping TrackedTipPipeline minimal makes it reusable across many downstream pipelines without coupling to any single analysis's opinions.
+
+**Why minimum-viable substrate, not full kinematics:** every downstream tip-aware pipeline needs (a) the raw `(t, x, y)` per track and (b) track-existence metadata (`tracking_coverage`) for filtering. Beyond those two, this pipeline emits only the unambiguous geometric scalars (`tip_trajectory_length`, `tip_displacement_net`) that have no detrending opinion. Derivative-based scalars (velocity, curvature) force a `frame_rate` decision and a "raw vs detrended" decision — those decisions belong in the downstream pipeline that owns the analysis (e.g. circumnutation analyses redefine velocity post-detrending). The substrate stays opinion-free so it serves every downstream consumer equally well.
+
+**Module placement:**
+
+- `sleap_roots/tracked_tip_pipeline.py` (NEW FILE) — `TrackedTipPipeline` class. Starts the per-pipeline-module pattern. Existing `trait_pipelines.py` megafile (3763 lines, 8 pipelines) split tracked in #189.
+- `sleap_roots/tip_kinematics.py` (NEW FILE) — pure trait functions parallel to `sleap_roots/lengths.py` and `sleap_roots/angle.py`.
+- `sleap_roots/series.py` (EXTEND) — new `Series.get_tracked_tips(root_type=None)` method + module-level validation helpers (`validate_tracked_slp`, `validate_series_for_tracked_tip`).
 
 **Inputs:**
 
-- `Series` with ONE of `primary_path` / `lateral_path` / `crown_path` populated. Pipeline is root-agnostic — works on whichever root type the SLEAP model tracked.
-- Predictions in the `.slp` MUST carry SLEAP track identities (`instance.track is not None`). Pipeline raises `ValueError("TrackedTipPipeline requires tracked .slp predictions; see sleap.ai/tracking")` if any instance lacks a track.
+- `Series` with ONE of `primary_path` / `lateral_path` / `crown_path` populated. Pipeline is root-agnostic — works on whichever root type the SLEAP model tracked. If multiple paths are populated, caller must specify `root_type` explicitly; otherwise `ValueError`.
+- Predictions in the `.slp` MUST carry SLEAP track identities (`instance.track is not None` for every instance). Pipeline raises `ValueError("TrackedTipPipeline requires tracked .slp predictions; see sleap.ai/tracking")` on the first untracked instance.
+- Optional CSV metadata via `Series.load(csv_path=...)` — when present, `sample_uid` and `timepoint` are emitted in output rows. (`sample_uid` defaults to `series.series_name` per Workstream 1; `timepoint` is `np.nan` when no CSV.)
+- **Single-node and multi-node skeletons both supported.** Tip is the LAST node by skeleton convention (`pts[-1]`), already used by `sleap_roots.tips.get_tips`. Verified on a single-node circumnutation skeleton (`['r0']`) — the `[:, -1, :]` slice degenerates to `[:, 0, :]`, which IS the only point. A future user training a multi-node tip skeleton (e.g. `[base, midpoint, tip]`) gets correct extraction for free.
 
 **Output (two tables, emitted together):**
 
 1. **Trajectory rows** (per-track-per-frame, raw positions):
    ```
-   series, sample_uid, track_id, frame, timepoint, tip_x, tip_y
+   series, sample_uid, timepoint, track_id, frame, tip_x, tip_y
    ```
-   One row per `(track_id, frame)`. Self-contained tip-position timeline suitable as input to downstream circumnutation analysis once that workstream lands.
+   One row per `(track_id, frame)`. Self-contained tip-position timeline suitable as input to downstream circumnutation analysis once that workstream lands. `frame` is the integer frame index in the .slp; real-time per-frame is **deferred to #186** (companion CSV via `Series.get_per_frame_metadata`). `timepoint` here is the per-series scalar (constant within a series), enabling uniform `TimeDiffPipeline` (Workstream 3) consumption across both tables.
 
-2. **Track summary rows** (per-track, growth-kinematic scalars):
+2. **Track summary rows** (per-track scalars — substrate only):
    ```
-   series, sample_uid, track_id, n_frames_tracked, n_frames_total, tracking_coverage,
-   tip_trajectory_length, tip_displacement_net, tip_velocity_mean, tip_velocity_max,
-   tip_curvature_mean, tip_curvature_max
+   series, sample_uid, timepoint, track_id, n_frames_tracked, n_frames_total,
+   tracking_coverage, tip_trajectory_length, tip_displacement_net
    ```
-   One row per `track_id`. Summary scalars over the whole trajectory.
+   One row per `track_id`. Substrate scalars only; **no derivative-based metrics in v1**.
 
-Both tables emit in one call. CSV/JSON contract inherits from the plate pipeline: `schema_version` (`2` after Workstream 1 ships — bumped from `1` because Workstream 1 inserts `sample_uid` + `timepoint` columns at positions 1 and 2, shifting every other column; non-additive change), structured `units` dict (now including `units["time"]` — initially `"unspecified"` until a `time_unit` plumbing path lands), NaN→null JSON via `_json_sanitize`.
+Both tables emit in one call. Output written to:
 
-**Tip-kinematics trait module** (`sleap_roots/tip_kinematics.py`, new):
+- **Per-series**: `<series>.tracked_tip_traits.csv` (summary), `<series>.tracked_tip_trajectories.csv` (trajectory), `<series>.tracked_tip_traits.json` (both tables under `{tracks: [...], trajectories: [...]}` plus top-level scalars).
+- **Batch** (`compute_batch_tracked_tip_traits(all_series)`): `tracked_tip_batch_traits.csv` (concatenated summary), `tracked_tip_batch_trajectories.csv` (concatenated trajectory), `tracked_tip_batch_traits.json` (list of per-series dicts). Mirrors PR #165's `compute_batch_plate_traits` pattern (`pd.concat` of per-series DataFrames; per-series result-dict list for JSON).
 
-Pure functions operating on `(t, x, y)` arrays, parallel to `sleap_roots/angle.py` and `sleap_roots/lengths.py`. The pipeline calls these in its TraitDef DAG.
+`emit_trajectories: bool = True` kwarg on both methods — when `False`, skip writing the trajectory CSV and omit the `trajectories` array from JSON. Lets users running large batches skip the bulky table when only summary scalars are needed. At realistic experiment scale this is rarely needed (4 plates × 6 tracks × 311 frames ≈ 7,500 rows, ~750 KB concatenated trajectory CSV — fine), but the kwarg costs nothing.
 
-Trait definitions (all per-track):
+**CSV/JSON contract:**
 
-| Trait | Definition | Units family |
-|---|---|---|
-| `tip_trajectory_length` | Cumulative arclength of raw `(x, y)` | lengths |
-| `tip_displacement_net` | Euclidean distance first → last point | lengths |
-| `tip_velocity_mean` | Mean `dt`-normalized step length | lengths / time |
-| `tip_velocity_max` | Max step length / `dt` | lengths / time |
-| `tip_curvature_mean` | Mean `abs(dθ/ds)` along trajectory | inverse_lengths |
-| `tip_curvature_max` | Max `abs(dθ/ds)` | inverse_lengths |
-| `tracking_coverage` | `n_frames_tracked / n_frames_total` | ratios (dimensionless) |
+- `schema_version: 1` at top-level JSON (fresh pipeline, starts at 1).
+- Structured `units` dict — `lengths: "pixels"`, `ratios: "dimensionless"`, `counts: "dimensionless"`, `time: "unspecified"` (Workstream 1's convention; future `time_unit` plumbing upgrades in place).
+- NaN → JSON `null` via `_json_sanitize` (existing helper from PR #165).
+- Top-level scalars (`series`, `sample_uid`, `timepoint`) in JSON do NOT repeat inside `tracks` / `trajectories` rows; CSV does repeat them on every row (PR #165's CSV/JSON asymmetry preserved).
+
+**`Series.get_tracked_tips(root_type=None)` (NEW ACCESSOR):**
+
+Returns a long-format `pd.DataFrame` with columns `track_id, frame, tip_x, tip_y`. One row per `(track_id, frame)` where the track has an instance.
+
+- Auto-detects `root_type` from whichever of `primary_path` / `lateral_path` / `crown_path` is populated; raises `ValueError` if zero or >1 are populated and `root_type` is `None`.
+- **Iterates per-instance, NOT per-frame-stack** — tracker output does NOT preserve positional ordering across frames. Verified on the fixture: frame 0 instances are ordered `[track_0, 1, 2, 3, 4, 5]` but frame 1 is `[track_0, 3, 4, 2, 1, 5]`. Implementation reads `inst.track.name` per instance and `inst.numpy()[-1]` for the tip coordinate.
+- Untracked instances (`inst.track is None` or `inst.track.name` falsy) trip `ValueError` with the sleap.ai/tracking pointer.
+
+**Tip-kinematics trait functions** (`sleap_roots/tip_kinematics.py`, NEW MODULE):
+
+Pure functions on `(N, 2)` xy arrays. The pipeline calls these in its `TraitDef` DAG.
+
+| Function | Definition | Single-frame behavior | Units family |
+|---|---|---|---|
+| `tip_trajectory_length(xy)` | Cumulative arclength: `sum(np.linalg.norm(np.diff(xy, axis=0), axis=1))` | `0.0` (no segments) | lengths |
+| `tip_displacement_net(xy)` | First → last Euclidean: `np.linalg.norm(xy[-1] - xy[0])` | `0.0` (xy[0] == xy[-1]) | lengths |
+| `tracking_coverage(n_tracked, n_total)` | `n_tracked / n_total` | well-defined for `n_tracked >= 1` | ratios |
+
+Single-frame tracks emit `length=0.0, displacement=0.0` — mathematically correct (no segments → no length); no NaN special-casing. Downstream filtering on `n_frames_tracked == 1` is the user's option.
+
+**DAG-A — TraitDef topology:**
+
+Pipeline uses the existing `TraitDef` graph plumbing (per `DicotPipeline` and friends), but the input is the long-format `tracked_tips_df` and the iteration unit is `track_id`, not `frame`:
+
+```
+tracked_tips_df  (input from series.get_tracked_tips())
+        │
+        │ groupby(track_id) → track_xy (Nx2)
+        ▼
+        ├─→ tip_trajectory_length(track_xy)
+        ├─→ tip_displacement_net(track_xy)
+        ├─→ tracking_coverage(n_frames_tracked, n_frames_total)
+        ├─→ n_frames_tracked
+        └─→ n_frames_total
+                │
+                ▼
+        per-track summary row
+```
+
+**Circumnutation and other downstream pipelines REUSE this substrate; they DO NOT extend `TrackedTipPipeline`.** A future `CircumnutationPipeline` is a separate class that consumes `series.get_tracked_tips(...)` (or this pipeline's trajectory CSV / JSON output) as its input substrate, runs its own `TraitDef` DAG with circumnutation-specific nodes, and emits its own per-track summary table. Conceptually:
+
+```
+                                    ┌──────────────────────────────────┐
+                                    │  Series.get_tracked_tips(...)    │
+                                    │  + TrackedTipPipeline trajectory │
+                                    │     CSV / JSON                   │
+                                    │  (THIS PR — frozen substrate)    │
+                                    └────────────────┬─────────────────┘
+                                                     │ reused as input
+                       ┌─────────────────────────────┼──────────────────────────────┐
+                       ▼                             ▼                              ▼
+              ┌──────────────────┐        ┌────────────────────┐         ┌──────────────────┐
+              │ CircumnutationPipe│        │ (future) GrowthRate│         │ (future) Gravi-  │
+              │ (NEXT PR — own   │        │ Pipeline           │         │ tropismPipeline  │
+              │  TraitDef DAG)    │        │ (own DAG, own CSV) │         │ (own DAG, own CSV)│
+              │  Period/amplitude/│        │ Velocity/accel etc.│         │ Angle vs gravity │
+              │  rotation etc.    │        │                    │         │                  │
+              └──────────────────┘        └────────────────────┘         └──────────────────┘
+```
+
+`TrackedTipPipeline`'s 5 substrate scalars stay frozen forever. New downstream pipelines come into existence as siblings, not as extensions of this one.
+
+**Validation helpers** (in scope for #129):
+
+- `sleap_roots.series.validate_tracked_slp(slp_path) -> None` — opens the .slp, asserts every instance has `inst.track is not None` AND `inst.track.name` is non-empty, raises `ValueError` listing offending frame indices if not. Module-level, paired with existing `find_all_slp_paths`.
+- `sleap_roots.series.validate_series_for_tracked_tip(series, root_type=None) -> None` — composite check: validates the relevant `<root_type>_path`, asserts skeleton has ≥1 node, calls `validate_tracked_slp`. Raises with actionable messages.
 
 **Edge cases** (deliberate behavior, tested):
 
-- Short tracks (`n_frames_tracked < 3`) — velocity / curvature scalars = NaN, no crash.
-- Single-frame track — NaN everywhere except `sample_uid` + `track_id` + `tracking_coverage`.
-- Partial tracking (gaps in frames) — compute on available window; `tracking_coverage < 1.0`.
-- Uneven frame spacing — use `timepoint` if column present, else `frame_rate` kwarg, else assume 1 unit per frame and document.
+- **Zero tracked instances anywhere** — pipeline emits empty `tracks` and `trajectories` arrays / empty CSVs, no crash.
+- **Single-frame track** — `length=0.0, displacement=0.0`, `n_frames_tracked=1`, `tracking_coverage > 0`, no NaN.
+- **Partial tracking (gaps)** — compute on available window; `tracking_coverage < 1.0`.
+- **Track-fragment / re-ID** — trust the tracker. If one physical tip becomes two `track_id`s in the source, two summary rows appear. **Documented assumption: input `.slp` is proofread.**
+- **Multiple root paths populated** — `ValueError` requesting explicit `root_type`.
+- **`track.name` is `None` or empty string** — treated as untracked; trips the "requires tracked .slp" `ValueError`.
+- **Single-node skeleton** (only the tip node) — supported via the `pts[-1]` convention; verified on the circumnutation fixture (`r0`-only skeleton).
+- **Multi-node skeleton** (e.g. `[base, midpoint, tip]`) — supported via the same `pts[-1]` convention.
 
 ### Deferred: circumnutation trait set
 
@@ -104,7 +180,7 @@ Circumnutation-specific traits (period, amplitude, angular velocity, rotation di
 - Is "amplitude" defined as radial distance from detrended mean, half peak-to-peak, or RMS of residuals?
 - How to define rotation direction when trajectory is noisy / partially tracked?
 
-The TrackedTipPipeline's trajectory-row output is the natural input to those analyses. When the circumnutation design lands, it can either be added as additional traits to TrackedTipPipeline (same pipeline, expanded trait set) or as a new trait module consumed by users who call `TrackedTipPipeline.compute_...` themselves. That decision is deferred with the rest of circumnutation.
+The TrackedTipPipeline's trajectory-row output (and `Series.get_tracked_tips` accessor) is the input substrate for those analyses. **The circumnutation trait set lives in a separate `CircumnutationPipeline` class** — it does NOT extend `TrackedTipPipeline`. Keeping `TrackedTipPipeline` minimal and opinion-free is what makes it reusable across multiple downstream pipelines (circumnutation today; growth-rate, gravitropism, and other tip-aware analyses tomorrow).
 
 ### Workstream 3 — `TimeDiffPipeline` (new)
 
@@ -186,11 +262,15 @@ Estimated size: ~150 lines including tests.
 | Issue | Action | Summary |
 |---|---|---|
 | #112 | Close as obsolete | Plate pipeline's frame loop + `TimeDiffPipeline` cover this scope. |
-| #129 | Refresh | Keep tip-kinematics scope (trajectory + velocity + curvature). Root-agnostic. Requires tracked `.slp`. Align output shape with the PR #165 contract (schema_version, structured units, `_json_sanitize`). |
+| #129 | Refresh (now scoped to **substrate**, not full kinematics) | Trajectory rows + 5 substrate scalars (`tip_trajectory_length`, `tip_displacement_net`, `tracking_coverage`, `n_frames_tracked`, `n_frames_total`). Root-agnostic. Requires tracked `.slp`. **Scope frozen** — velocity / curvature / circumnutation traits do NOT belong in this pipeline; they live in separate downstream pipeline classes that REUSE the substrate. Output contract aligns with PR #165 (`schema_version=1`, structured units, `_json_sanitize`). |
 | #159 | Keep (related) | Multi-plant cylinder per-plant diffs blocked on this. |
-| #163 | Broaden | Add `sample_uid` column convention (fallback to `plant_qr_code`); add `timepoint` column convention. |
-| NEW | File | `TimeDiffPipeline` wrapper class. |
-| NEW | File | `sample_uid` + `timepoint` metadata layer + `Series.get_metadata()` generalized accessor + `sleap_roots/metadata.py` CSV builder helpers. |
+| #163 | Broaden | Add `sample_uid` column convention (fallback to `plant_qr_code`); add `timepoint` column convention; rename legacy `plant_qr_code` column. |
+| #169 | Implemented (PR #171) | Workstream 1 metadata layer shipped 2026-05-06. |
+| #170 | Keep (Workstream 3) | `TimeDiffPipeline` wrapper class. |
+| #186 | Filed 2026-05-06 (Workstream 2 follow-up) | Per-frame metadata accessor on `Series` (`get_per_frame_metadata`, companion CSV). Required for any pipeline that needs real-time-per-frame; not blocking #129 (substrate uses integer `frame` only). |
+| #187 | Filed 2026-05-06 (Workstream 2 follow-up) | Preprocessing helpers: image folder → `.h5` + per-frame metadata CSV. Captures the upstream of the data-prep workflow. |
+| #188 | Filed 2026-05-06 (Workstream 2 follow-up) | Generic source-META → sleap-roots-CSV converter (`convert_meta_to_qr_csv`). Captures the experiment-metadata side. |
+| #189 | Filed 2026-05-06 (triggered by #129) | Refactor: split `trait_pipelines.py` (3763 lines, 8 pipelines) into per-pipeline modules. #129 starts the per-pipeline-file pattern by living in `sleap_roots/tracked_tip_pipeline.py`. |
 | NEW (deferred) | File once literature is assembled | Circumnutation trait set (period, amplitude, angular velocity, rotation direction, etc.) — depends on Workstream 2 shipping first so the trajectory-row output exists. |
 
 ## Identity table (reference)
@@ -209,6 +289,11 @@ Decision-cheatsheet for users choosing `identity_cols` and `time_col`:
 
 ## Out of scope (deferred)
 
+- **Velocity / curvature / smoothness / tortuosity / direction-changes traits** — these are NEVER added to `TrackedTipPipeline`. They live in separate downstream pipeline classes (e.g. a future `CircumnutationPipeline`, `GrowthRatePipeline`, etc.) that REUSE this pipeline's `Series.get_tracked_tips` accessor and trajectory output as their input substrate. `TrackedTipPipeline`'s scope is frozen at the substrate so it remains opinion-free and reusable across many downstream pipelines.
+- **Per-frame real-time timestamps** in `TrackedTipPipeline` output — deferred to **#186** (per-frame metadata accessor on `Series`). Substrate uses integer `frame` column only.
+- **Image folder → `.h5` + per-frame metadata CSV preprocessing** — deferred to **#187**. Captures the upstream of the data-prep workflow (raw imaging output → sleap-roots-readable inputs).
+- **Generic source-META → sleap-roots-CSV conversion helpers** — deferred to **#188**. Captures the experiment-metadata side of the data-prep workflow.
+- **Splitting `trait_pipelines.py` into per-pipeline modules** — deferred to **#189**. `TrackedTipPipeline` lands in its own new file (`sleap_roots/tracked_tip_pipeline.py`), starting the pattern.
 - **Circumnutation trait set** (period, amplitude, angular velocity, rotation direction, n_nutation_cycles, detrending method) — deferred to a separate design once the maintainer has assembled a literature reference. Workstream 2's trajectory-row output is the natural input.
 - **Spatial matching of plant IDs across scans** — D3 in the brainstorm. Fragile; file follow-up only if user demand materializes.
 - **Date-string parsing into numeric timepoints** (`"2024-03-15"` → day number) — too domain-specific. User responsibility.
@@ -234,8 +319,8 @@ Same discipline as PR #165 — synthetic `.slp` round-trip for integration tests
 
 Each workstream gets its own OpenSpec change:
 
-- `change-id: add-sample-uid-timepoint-metadata` (Workstream 1)
-- `change-id: add-tracked-tip-pipeline` (Workstream 2 — kinematics only; no circumnutation)
+- `change-id: add-sample-uid-timepoint-metadata` (Workstream 1 — shipped via PR #171, archived 2026-05-06)
+- `change-id: add-tracked-tip-pipeline` (Workstream 2 — substrate scope: trajectory + 5 per-track scalars; no velocity / curvature / circumnutation)
 - `change-id: add-time-diff-pipeline` (Workstream 3)
 
 When the circumnutation literature is assembled, a fourth change (`add-circumnutation-traits` or similar) picks up that scope on top of Workstream 2's trajectory-row output.
@@ -258,18 +343,28 @@ Per-workstream fixture plan. PR #165 shipped synthetic-only with real fixtures d
 
 Synthetic coverage (primary test surface):
 
-- Pure trait functions in `sleap_roots/tip_kinematics.py` against known `(t, x, y)` arrays.
-- Pipeline DAG, CSV/JSON emission, empty-input / single-frame / short-track edge cases via synthetic `.slp` files with `sio.Track` objects attached to `sio.Instance` via `from_numpy(..., track=...)`.
+- Pure trait functions in `sleap_roots/tip_kinematics.py` against known `(N, 2)` arrays — exact-value assertions on multi-segment trajectories, single-frame degenerate case (`length=0.0, displacement=0.0`), known geometric shapes (square, straight line).
+- `Series.get_tracked_tips` accessor on synthetic `.slp` files with `sio.Track` objects attached to `sio.Instance` via `from_numpy(..., track=...)` — exercises root-type auto-detection, multiple-paths-populated `ValueError`, untracked-instance `ValueError`, single-node and multi-node skeleton paths.
+- Pipeline DAG, CSV/JSON emission, batch concat, `emit_trajectories=False` skip path, empty-input / single-frame / short-track edge cases — all via synthetic `.slp` files.
 
-Real-fixture coverage (added before PR merge):
+Real-fixture coverage (committed in the PR):
 
-- Source: `Z:\users\eberrigan\circumnutation` — plate timelapse with tracked tips.
-- Copy ONE small subset into `tests/data/circumnutation_plate/` (target: single plant, ≤30 frames, compressed). Commit via Git LFS.
-- **Fixture README required**: `tests/data/circumnutation_plate/README.md` following the standard template from issue #168 (purpose, imaging geometry, acquisition context, contents, known limitations, related issues). The new fixture lands with documentation from day one so Workstream 2's PR does not add to the existing test-data documentation debt.
-- One integration test: `Series.load` on the real `.slp` → `TrackedTipPipeline.compute_...` → assert every trait column is present, `tracking_coverage ∈ [0, 1]`, trajectory row count equals tracked-instance count. No exact trait value assertions (those belong in synthetic tests where the geometry is controlled).
-- Purpose: catch sleap-io track-representation drift, real tracker-output edge cases (births, deaths, gaps, re-IDs), ensure the sleap-io loading path works on real tracked predictions.
+- **Source**: `Z:\users\eberrigan\circumnutation\20250819_Suyash_Patil_CMTN_Kitx_vs_Hk1-3_07-30-25\run_20250827_091833\plate_001_greyscale.tracked.slp` (verified 2026-05-06) — 311 frames, 6 tracks, single-node skeleton (`['r0']`), HDF5 video backend.
+- **Fixture file**: `tests/data/circumnutation_plate/plate_001_greyscale.tracked.slp` — **184 KB**. Take the WHOLE 311-frame plate as-is (no subsetting needed; size is comfortably under git-LFS thresholds). Commit via Git LFS.
+- **Fixture metadata CSV**: `tests/data/circumnutation_plate/fixture_metadata.csv` — synthesized BY HAND (one-time, NOT a script) from `CMTN_KITXvsHK1-3_META.csv`'s plate-1 row. Schema follows the existing `plant_qr_code`-keyed convention (legacy column name; rename tracked in #163):
+  ```
+  plant_qr_code,genotype,treatment,number_of_plants_cylinder,timepoint
+  plate_001,KitaakeX,MOCK,6,0
+  ```
+  README documents the column-name caveat (`plant_qr_code` value `"plate_001"` is a plate identifier, not a plant identifier; `number_of_plants_cylinder` is a misnomer here — no cylinder).
+- **Per-frame metadata** (`plate_001_metadata.csv` from the source) is **deliberately NOT shipped** — consumed only after #186 lands. README points to #186 as the path forward for real-time-per-frame consumption.
+- **Fixture README required**: `tests/data/circumnutation_plate/README.md` following the standard template from issue #168 (purpose, imaging geometry, acquisition context, contents, known limitations, related issues, conversion provenance). The new fixture lands with documentation from day one so Workstream 2's PR does not add to the existing test-data documentation debt.
+- **Integration tests** (two paths exercise both CSV-plumbing and no-CSV branches):
+  1. `Series.load(primary_path=..., csv_path=fixture_metadata.csv, sample_uid="plate_001")` → `TrackedTipPipeline.compute_tracked_tip_traits(series)` → assert: every output column present, `tracking_coverage ∈ [0, 1]` for every track, summary row count equals 6 (tracks), trajectory row count equals total tracked instances (311 frames × 6 tracks where every frame has 6 tracked instances → 1866 rows). No exact trait-value assertions (those belong in synthetic tests).
+  2. `Series.load(primary_path=...)` (NO `csv_path`) → same pipeline call → assert `sample_uid` defaults to `series_name`, `timepoint` is NaN, all other columns identical to (1).
+- **Purpose**: catch sleap-io track-representation drift, real tracker-output edge cases (track-order non-determinism across frames — verified during brainstorm), ensure single-node skeleton path works on real tracked predictions.
 
-**Gate on PR merge**: either the real fixture lands with the PR OR a follow-up issue is filed before the PR is marked ready for review (same discipline as PR #165's #162). Given the source data is available today, the intent is to ship it in the PR.
+**Gate on PR merge**: real fixture lands WITH the PR (source data is available; size is small). No follow-up deferral.
 
 ### Workstream 3 — `TimeDiffPipeline`
 
@@ -297,4 +392,6 @@ The source folders under `Z:\users\eberrigan\` are the maintainer's working copi
 | `TimeDiffPipeline` diverges from inner pipeline method signatures | Delegate via `getattr(inner, method)(*args, **kwargs)` and let Python's arg-binding enforce compatibility. Test against each supported inner pipeline. |
 | SLEAP tracking is expensive / not commonly enabled | Document sleap tracking workflow in `TrackedTipPipeline`'s docstring; raise with a link to sleap docs on untracked input. |
 | Users have existing `plant_qr_code`-based workflows that expect per-scan rows to have unique values | No change for them — the kwarg default is `series_name`, which already produces unique per-scan rows. |
-| TrackedTipPipeline output shape might need to change when circumnutation lands | Output spec for Workstream 2 is deliberately minimal and extensible — adding circumnutation scalars as new per-track columns is additive and bumps `schema_version` only if removal/rename is needed. |
+| Users expect velocity / curvature / kinematic scalars in `TrackedTipPipeline` from the original #129 scope | Document explicitly in the pipeline docstring + README that `TrackedTipPipeline` is the minimum-viable substrate, scope frozen. Velocity / curvature etc. live in separate downstream pipelines (e.g. future `CircumnutationPipeline`) — never added to `TrackedTipPipeline`. The trajectory-row output + `Series.get_tracked_tips` accessor are the input substrate for those analyses. |
+| Track-order non-determinism across frames could be assumed away accidentally during refactors | `Series.get_tracked_tips` iterates per-instance and reads `inst.track.name` per instance — never relies on positional ordering. Documented in the accessor's docstring with the verified example from the fixture brainstorm (frame 0: `[0,1,2,3,4,5]`; frame 1: `[0,3,4,2,1,5]`). Test asserts that two adjacent frames with shuffled positional order still produce identically-keyed track rows. |
+| Single-node skeleton support breaks if the `[-1]` convention is changed | `[-1]` slice is the established convention in `sleap_roots.tips.get_tips`. Test asserts the accessor works on both single-node (`['r0']`) and multi-node skeletons. |

--- a/docs/superpowers/specs/2026-04-23-timelapse-diff-and-tip-kinematics-design.md
+++ b/docs/superpowers/specs/2026-04-23-timelapse-diff-and-tip-kinematics-design.md
@@ -101,17 +101,39 @@ Returns a long-format `pd.DataFrame` with columns `track_id, frame, tip_x, tip_y
 - **Iterates per-instance, NOT per-frame-stack** — tracker output does NOT preserve positional ordering across frames. Verified on the fixture: frame 0 instances are ordered `[track_0, 1, 2, 3, 4, 5]` but frame 1 is `[track_0, 3, 4, 2, 1, 5]`. Implementation reads `inst.track.name` per instance and `inst.numpy()[-1]` for the tip coordinate.
 - Untracked instances (`inst.track is None` or `inst.track.name` falsy) trip `ValueError` with the sleap.ai/tracking pointer.
 
-**Tip-kinematics trait functions** (`sleap_roots/tip_kinematics.py`, NEW MODULE):
+**Tip-kinematics trait functions** (`sleap_roots/tip_kinematics.py`, NEW MODULE — thin wrappers around existing trait functions):
 
-Pure functions on `(N, 2)` xy arrays. The pipeline calls these in its `TraitDef` DAG.
+Pure functions on `(N, 2)` xy arrays. The pipeline calls these in its `TraitDef` DAG. **DRY-driven: the actual numpy computation lives in `sleap_roots/lengths.py` and `sleap_roots/bases.py` already.** This new module exists to (a) document tip-trajectory-specific edge cases and (b) provide a stable import path for future tip-trajectory-aware pipelines.
 
-| Function | Definition | Single-frame behavior | Units family |
+| Function | Computation source | Single-frame behavior | Units family |
 |---|---|---|---|
-| `tip_trajectory_length(xy)` | Cumulative arclength: `sum(np.linalg.norm(np.diff(xy, axis=0), axis=1))` | `0.0` (no segments) | lengths |
-| `tip_displacement_net(xy)` | First → last Euclidean: `np.linalg.norm(xy[-1] - xy[0])` | `0.0` (xy[0] == xy[-1]) | lengths |
-| `tracking_coverage(n_tracked, n_total)` | `n_tracked / n_total` | well-defined for `n_tracked >= 1` | ratios |
+| `tip_trajectory_length(xy)` | Delegates to [`lengths.get_root_lengths`](sleap_roots/lengths.py#L56) (cumulative arclength via `np.diff` + `np.linalg.norm` + `np.nansum`). Wrapper special-cases single-frame to return `0.0` instead of NaN (existing function's vacuous-truth NaN behavior on empty segments). | `0.0` (no segments) | lengths |
+| `tip_displacement_net(xy)` | Delegates to [`bases.get_base_tip_dist`](sleap_roots/bases.py#L34) (Euclidean via `np.linalg.norm`). Pass `xy[0]` as base, `xy[-1]` as tip. | `0.0` (xy[0] == xy[-1] — natural, no special-case) | lengths |
+| `tracking_coverage(n_tracked, n_total)` | Trivial division — no existing utility. ~3 lines. | well-defined for `n_tracked >= 1` | ratios |
 
-Single-frame tracks emit `length=0.0, displacement=0.0` — mathematically correct (no segments → no length); no NaN special-casing. Downstream filtering on `n_frames_tracked == 1` is the user's option.
+Single-frame tracks emit `length=0.0, displacement=0.0` — mathematically correct (no segments → no length); no NaN special-casing in the pipeline output. Downstream filtering on `n_frames_tracked == 1` is the user's option.
+
+**Implementation sketch** (~30 lines total — nearly all delegation):
+
+```python
+from sleap_roots.lengths import get_root_lengths
+from sleap_roots.bases import get_base_tip_dist
+
+def tip_trajectory_length(xy: np.ndarray) -> float:
+    if xy.shape[0] == 0: return np.nan
+    if xy.shape[0] == 1: return 0.0
+    return float(get_root_lengths(xy))
+
+def tip_displacement_net(xy: np.ndarray) -> float:
+    if xy.shape[0] == 0: return np.nan
+    return float(get_base_tip_dist(xy[0], xy[-1]))
+
+def tracking_coverage(n_frames_tracked: int, n_frames_total: int) -> float:
+    if n_frames_total == 0: return np.nan
+    return n_frames_tracked / n_frames_total
+```
+
+Existing functions in `lengths.py` / `bases.py` have full test coverage and known NaN semantics. The wrappers' tests just cover the tip-trajectory-specific edge cases (single-frame zeros, empty input).
 
 **DAG-A — TraitDef topology:**
 

--- a/notebooks/TrackedTipPipeline_Mermaid_Graph.md
+++ b/notebooks/TrackedTipPipeline_Mermaid_Graph.md
@@ -1,0 +1,12 @@
+```mermaid
+graph LR
+    track_xy --> track_first_xy
+    track_xy --> track_last_xy
+    track_first_xy --> tip_displacement_net
+    track_last_xy --> tip_displacement_net
+    track_xy --> tip_trajectory_length
+    n_frames_tracked --> tracking_coverage
+    n_frames_total --> tracking_coverage
+```
+
+Distinct Traits for TrackedTipPipeline: 8

--- a/openspec/changes/add-tracked-tip-pipeline/design.md
+++ b/openspec/changes/add-tracked-tip-pipeline/design.md
@@ -1,0 +1,96 @@
+# Design: `add-tracked-tip-pipeline`
+
+**Architectural source of truth**: [`docs/superpowers/specs/2026-04-23-timelapse-diff-and-tip-kinematics-design.md`](../../../docs/superpowers/specs/2026-04-23-timelapse-diff-and-tip-kinematics-design.md) § Workstream 2.
+
+That document captures the brainstorm decisions: substrate-only scope (no velocity/curvature in v1, no circumnutation traits ever), pure DAG-A composition reusing existing trait functions, single-frame edge-case asymmetry trade-off, real-fixture choice and synthesis, and the four follow-up issues (#186 / #187 / #188 / #189) the substrate work-stream surfaced.
+
+## OpenSpec-specific design notes
+
+### Single new capability, no MODIFIED deltas
+
+This change introduces ONE new capability `tracked-tip-pipeline` with all ADDED requirements. No existing capabilities are modified.
+
+Reasoning:
+- The new `Series.get_tracked_tips` method and the two `validate_*` helpers are additive to `Series` — no observable contract change to `series-metadata` or any existing pipeline.
+- Bundling the Series-side accessor + validators alongside the pipeline class in ONE capability keeps the substrate's contract internally coherent. Splitting "Series accessor" from "pipeline that consumes the accessor" would scatter the spec across capabilities and obscure the substrate-as-a-whole.
+- `series-metadata` (PR #171) is scoped to CSV-metadata-lookup concerns — `get_tracked_tips` is a track-aware data-extraction method that doesn't fit that scope.
+
+### Why a NEW pipeline file (`tracked_tip_pipeline.py`)
+
+Existing `trait_pipelines.py` is 3763 lines with 8 pipeline classes. Adding a 9th would push it further. The user explicitly chose to start the per-pipeline-file pattern with this PR; the megafile split for the existing 8 is tracked in **#189**.
+
+Backward compatibility: top-level `from sleap_roots import TrackedTipPipeline` works via `__init__.py` re-export. Code reviewers and grep-for-pipelines users find it where they'd expect (a file named after the pipeline).
+
+### Why DAG-A composition with existing trait functions
+
+The user-visible decision: **no new trait module** (`tip_kinematics.py` was originally proposed and dropped). Existing functions plug in directly via TraitDef DAG composition:
+
+- `tip_displacement_net` ← `bases.get_base_tip_dist` (with DAG-provided slicing of `track_first_xy` / `track_last_xy`)
+- `tip_trajectory_length` ← `lengths.get_root_lengths` (consumes `track_xy` directly)
+- `tracking_coverage` ← inline lambda
+
+Reasoning:
+- DRY by maximum reuse — the existing functions have full unit-test coverage and known NaN semantics. The new pipeline's tests cover **composition** (does the DAG correctly route `track_first_xy` and `track_last_xy` into `get_base_tip_dist`), not the underlying numpy.
+- No wrapper-module overhead. The pipeline file itself holds the small lambdas inline in TraitDef definitions.
+- Trade-off accepted: single-frame `tip_trajectory_length=NaN` (codebase convention from `get_root_lengths`'s NaN-on-empty-segments guard) instead of the `0.0` originally proposed in brainstorm. Asymmetry with `tip_displacement_net=0.0` (which is naturally 0.0 from `get_base_tip_dist` when `xy[0]==xy[-1]`) is documented; users `fillna(0.0)` or filter on `n_frames_tracked > 1`.
+
+### Why per-track DAG iteration (not per-frame)
+
+Existing pipelines (DicotPipeline, plate pipeline, etc.) iterate per-frame: the DAG runs once per frame on `(instances, nodes, 2)` arrays. TrackedTipPipeline operates on a fundamentally different axis — per-track time series (Nx2 array of one tip's positions across frames).
+
+The pipeline's `compute_tracked_tip_traits`:
+1. Calls `series.get_tracked_tips()` to get long-format DataFrame (sorted by `(track_id, frame)`).
+2. Iterates `for track_id, group in df.groupby('track_id'):` and runs the DAG once per track group, with `track_xy = group[['tip_x','tip_y']].values`.
+3. Aggregates per-track summary rows.
+
+The DAG topology IS the same idea (TraitDef nodes with dependencies, networkx-driven topo sort), just with a different iteration unit. No changes to the `Pipeline` base class needed — `compute_tracked_tip_traits` is the entry point and it controls iteration.
+
+### Why `Series.get_tracked_tips` returns frame-sorted rows
+
+`tip_displacement_net = ||xy[-1] - xy[0]||` is correct only if `xy[0]` is the first-tracked-frame tip and `xy[-1]` is the last. Tracker output is NOT in frame-sorted order naturally — verified during brainstorm: frame 0 instances are `[track_0, 1, 2, 3, 4, 5]` but frame 1 is `[track_0, 3, 4, 2, 1, 5]`. Sorting at the accessor (`df.sort_values(['track_id', 'frame']).reset_index(drop=True)`) is the cheapest place to enforce the invariant — every downstream consumer gets the right ordering for free.
+
+The spec codifies this as a normative requirement with a regression test that constructs a synthetic .slp where instance positional order is randomized per frame, then asserts the accessor's output is frame-sorted.
+
+### Why iterate per-instance (not per-frame stack) in `get_tracked_tips`
+
+The existing `get_primary_points` does `np.stack([inst.numpy() for inst in lf.instances])` — collapses to a `(n_inst, n_nodes, 2)` array per frame, losing track identity since you can't pair `inst.track.name` with array rows after stacking.
+
+`get_tracked_tips` instead:
+```python
+for frame_idx in range(len(labels)):
+    for inst in labels[frame_idx].instances:
+        if inst.track is None: raise ValueError(...)
+        rows.append({
+            "track_id": inst.track.name,
+            "frame": frame_idx,
+            "tip_x": inst.numpy()[-1, 0],
+            "tip_y": inst.numpy()[-1, 1],
+        })
+return pd.DataFrame(rows).sort_values(["track_id", "frame"]).reset_index(drop=True)
+```
+
+Slightly slower than vectorized stack for large frame counts, but correct. At realistic data scale (~2,000 rows for a 311-frame plate × 6 tracks) the difference is negligible (~10ms).
+
+### Real fixture provenance and minimum required content
+
+The fixture (`tests/data/circumnutation_plate/`) ships these files:
+- `plate_001_greyscale.tracked.slp` (184 KB, Git LFS) — copied verbatim from the source.
+- `fixture_metadata.csv` — synthesized by hand: ONE row, `plant_qr_code="plate_001"`, `genotype="KitaakeX"`, `treatment="MOCK"`, `number_of_plants_cylinder=6`, `timepoint=0`. Uses the existing repo CSV convention so `Series.get_metadata` lookups work without modification.
+- `README.md` — provenance + the legacy-name caveat.
+
+Why no per-frame CSV: per-frame metadata is deferred to #186. This PR's substrate uses integer `frame` only.
+
+Why one plate (not all 4): one plate exercises the full pipeline path. Multi-plate batch testing happens with synthetic `.slp` files in unit tests.
+
+### Test strategy: synthetic-first, real-fixture for integration
+
+Synthetic tests (primary surface):
+- `Series.get_tracked_tips` accessor — auto-detect, frame-sorted output, untracked-instance error, single-node + multi-node skeleton paths.
+- TrackedTipPipeline DAG composition — exact-value assertions on known geometric shapes (straight line, right-angle, square).
+- CSV / JSON emission — empty-input, single-frame, partial-tracking, batch concat, `emit_trajectories=False` skip path.
+
+Real-fixture tests (integration surface — two paths):
+1. WITH `csv_path=fixture_metadata.csv`: assert `sample_uid="plate_001"`, `timepoint=0.0`, all output columns present, `tracking_coverage ∈ [0, 1]`, summary row count = 6, trajectory row count = 1866 (311 frames × 6 tracks).
+2. WITHOUT `csv_path`: same pipeline call, assert `sample_uid` defaults to `series_name`, `timepoint` is NaN, all other column values identical to (1).
+
+No exact trait-value assertions on real-fixture tests — those belong in synthetic tests where the geometry is controlled.

--- a/openspec/changes/add-tracked-tip-pipeline/proposal.md
+++ b/openspec/changes/add-tracked-tip-pipeline/proposal.md
@@ -1,0 +1,101 @@
+# Add `TrackedTipPipeline` (Workstream 2 of the 2026-04-23 timelapse design)
+
+## Why
+
+Issue #129 needs a root-agnostic pipeline that consumes **tracked** SLEAP `.slp` predictions and emits per-track tip-trajectory data plus a minimum-viable substrate of per-track geometric scalars. The existing `Series` accessors (`get_primary_points` / `get_lateral_points` / `get_crown_points`) call `.numpy()` on labels and DROP track identity — they cannot be reused for track-aware analysis.
+
+This pipeline is the **substrate** for downstream tip-aware analyses (circumnutation, growth-rate, gravitropism). Its scope is deliberately frozen: trajectory rows + 5 per-track scalars (`n_frames_tracked`, `n_frames_total`, `tracking_coverage`, `tip_trajectory_length`, `tip_displacement_net`). Velocity, curvature, and circumnutation traits NEVER belong here — they live in separate downstream pipeline classes that REUSE this pipeline's `Series.get_tracked_tips` accessor and trajectory output as their input substrate. Keeping `TrackedTipPipeline` minimal makes it reusable across many downstream pipelines without coupling to any single analysis's opinions.
+
+Workstream 1 (PR #171, archived) shipped the metadata layer this pipeline depends on (`Series.sample_uid`, `Series.timepoint`, `Series.get_metadata`). Workstream 3 (`TimeDiffPipeline`, #170) depends on this pipeline emitting per-row-over-time output.
+
+## What Changes
+
+### NEW pipeline class
+
+- **NEW** `sleap_roots/tracked_tip_pipeline.py` — `TrackedTipPipeline(Pipeline)` class. Lives in its own file (NOT appended to `trait_pipelines.py`). Starts the per-pipeline-module pattern; the existing `trait_pipelines.py` megafile (3763 lines, 8 pipelines) split is tracked in **#189**.
+- **NEW** `TrackedTipPipeline.compute_tracked_tip_traits(series, write_csv=False, write_json=False, output_dir=".", emit_trajectories=True, ...)` — single-series method. Returns a per-series result dict; optionally writes one summary CSV, one trajectory CSV (suppressed when `emit_trajectories=False`), and one JSON file.
+- **NEW** `TrackedTipPipeline.compute_batch_tracked_tip_traits(all_series, ...)` — batch method mirroring the existing `compute_batch_plate_traits` pattern in [trait_pipelines.py:3327](sleap_roots/trait_pipelines.py#L3327). Walks the input list, calls the per-series method, concatenates per-series DataFrames, writes batch CSVs + a JSON list of per-series dicts.
+
+### NEW Series accessor + validation helpers
+
+- **NEW** `Series.get_tracked_tips(root_type: Optional[Literal["primary", "lateral", "crown"]] = None) -> pd.DataFrame` — returns long-format `(track_id, frame, tip_x, tip_y)` rows, sorted by `(track_id, frame)`. Iterates per-instance (not per-frame-stack) because tracker output does NOT preserve positional ordering across frames. Auto-detects `root_type` from whichever of `primary_path` / `lateral_path` / `crown_path` is populated. Raises `ValueError` on (a) zero or >1 paths populated with `root_type=None`, (b) any instance with `inst.track is None` or empty `inst.track.name`.
+- **NEW** module-level `validate_tracked_slp(slp_path: Union[str, Path]) -> None` in `series.py` — opens the .slp, asserts every instance has a non-empty track, raises `ValueError` listing offending frame indices.
+- **NEW** module-level `validate_series_for_tracked_tip(series: Series, root_type: Optional[str] = None) -> None` in `series.py` — composite check: validates the relevant `<root_type>_path`, asserts skeleton has ≥1 node, calls `validate_tracked_slp` on the resolved path.
+
+### Trait functions — DAG-A composition (no new trait module)
+
+The pipeline's TraitDef DAG reuses existing tested trait functions DIRECTLY. **No `tip_kinematics.py` module is created.** The DAG provides per-track input slicing (`track_first_xy`, `track_last_xy`); existing functions plug in unchanged:
+
+- `tip_displacement_net` — TraitDef with `fn=bases.get_base_tip_dist`, `input_traits=["track_first_xy", "track_last_xy"]`. Single-frame returns `0.0` naturally (xy[0] == xy[-1]).
+- `tip_trajectory_length` — TraitDef with `fn=lengths.get_root_lengths`, `input_traits=["track_xy"]`. Single-frame returns `NaN` (codebase's NaN-on-empty-segments convention from `get_root_lengths`).
+- `tracking_coverage` — TraitDef with inline lambda `fn=lambda nt, ntot: nt/ntot if ntot else np.nan`, `input_traits=["n_frames_tracked", "n_frames_total"]`.
+
+Single-frame edge-case asymmetry (`tip_displacement_net=0.0`, `tip_trajectory_length=NaN`) is **deliberate and documented** — the cost of using `get_root_lengths` directly without a wrapper. Users who want either filtered or coerced apply `fillna(0.0)` post-hoc; users who want only "real trajectories" filter on `n_frames_tracked > 1`.
+
+### Output contract
+
+**Two tables, both emitted in one call:**
+
+1. **Trajectory rows** (`<series>.tracked_tip_trajectories.csv` — one row per `(track_id, frame)`):
+   ```
+   series, sample_uid, timepoint, track_id, frame, tip_x, tip_y
+   ```
+2. **Track summary rows** (`<series>.tracked_tip_traits.csv` — one row per `track_id`):
+   ```
+   series, sample_uid, timepoint, track_id, n_frames_tracked, n_frames_total,
+   tracking_coverage, tip_trajectory_length, tip_displacement_net
+   ```
+
+**JSON** (`<series>.tracked_tip_traits.json`): single dict with `schema_version: 1`, `pipeline: "TrackedTipPipeline"`, structured `units` dict (`lengths: "pixels"`, `ratios: "dimensionless"`, `counts: "dimensionless"`, `time: "unspecified"`), top-level scalars (`series`, `sample_uid`, `timepoint`), and both tables under `{"tracks": [...], "trajectories": [...]}`. Top-level scalars do NOT repeat inside per-row arrays in JSON (they DO repeat in CSV — PR #165's CSV/JSON asymmetry).
+
+**Batch**: `tracked_tip_batch_traits.csv` (concatenated summary), `tracked_tip_batch_trajectories.csv` (concatenated trajectory), `tracked_tip_batch_traits.json` (list of per-series dicts). Mirrors PR #165's `compute_batch_plate_traits` pattern.
+
+**`emit_trajectories: bool = True` kwarg** on both compute methods — when `False`, skips writing the trajectory CSV and omits the `trajectories` array from JSON. At realistic data scale (~7,500 rows for a 4-plate experiment, ~750 KB) the kwarg is rarely needed, but it costs nothing.
+
+### Real-data test fixture
+
+- **NEW** `tests/data/circumnutation_plate/plate_001_greyscale.tracked.slp` — 184 KB tracked predictions sliced from `Z:\users\eberrigan\circumnutation\20250819_Suyash_Patil_CMTN_Kitx_vs_Hk1-3_07-30-25\run_20250827_091833\plate_001_greyscale.tracked.slp` (verified 2026-05-06: 311 frames, 6 tracks named `track_0..track_5`, single-node skeleton `['r0']`, HDF5 video backend, all instances tracked). Committed via Git LFS.
+- **NEW** `tests/data/circumnutation_plate/fixture_metadata.csv` — synthesized BY HAND (one-time, not a script) from `CMTN_KITXvsHK1-3_META.csv`'s plate-1 row. Single row keyed `plant_qr_code="plate_001"`. Schema follows existing `plant_qr_code`-keyed convention (legacy column name; rename tracked in #163).
+- **NEW** `tests/data/circumnutation_plate/README.md` — fixture documentation per the standard template (issue #168). Covers: source provenance, conversion steps, the `plant_qr_code` legacy-name caveat (value `"plate_001"` is a plate identifier, not a plant identifier), why per-frame metadata is NOT shipped (deferred to #186), related issues.
+
+## Impact
+
+### Affected specs
+
+- **NEW capability** `tracked-tip-pipeline` — ADDED requirements covering: pipeline class location, output contract (CSV + JSON for per-series and batch), `emit_trajectories` kwarg, edge cases (zero tracks, single-frame, partial tracking, multiple paths populated, untracked instance, single-node skeleton, multi-node skeleton, track-order non-determinism), `Series.get_tracked_tips` accessor, validation helpers, trait DAG composition.
+
+No existing capabilities are MODIFIED by this change — `series-metadata` (PR #171) and `multiple-dicot-plate-pipeline` (PR #165) stay as-is. The new accessor + validators on `Series` are additive (no observable contract change to existing `Series` methods).
+
+### Affected code
+
+- `sleap_roots/tracked_tip_pipeline.py` — NEW FILE (~150 lines). Contains `TrackedTipPipeline` class with `traits` list (DAG-A topology) and the two `compute_*` methods.
+- `sleap_roots/series.py` — EXTEND. Add `Series.get_tracked_tips` method (~50 lines including auto-detection + per-instance iteration), `validate_tracked_slp`, `validate_series_for_tracked_tip` (~30 lines combined).
+- `sleap_roots/__init__.py` — re-exports `TrackedTipPipeline` (top-level), `validate_tracked_slp`, `validate_series_for_tracked_tip`.
+- `tests/test_tracked_tip_pipeline.py` — NEW FILE. Synthetic-`.slp` integration tests for the pipeline + DAG composition tests.
+- `tests/test_series.py` — EXTEND. New tests for `get_tracked_tips` (auto-detect, ordering, untracked-instance error, single-node skeleton, multi-node skeleton) + the two validators.
+- `tests/data/circumnutation_plate/` — NEW directory with fixture .slp + fixture_metadata.csv + README.md (committed via Git LFS).
+- No existing code is modified — additive throughout.
+
+### Source design doc
+
+[`docs/superpowers/specs/2026-04-23-timelapse-diff-and-tip-kinematics-design.md`](docs/superpowers/specs/2026-04-23-timelapse-diff-and-tip-kinematics-design.md) § Workstream 2.
+
+### Dependencies
+
+- **Depends on**: PR #171 (Workstream 1 metadata layer — `Series.sample_uid`, `Series.timepoint`, `Series.get_metadata`). Already merged.
+- **Depends on**: PR #165 (`MultipleDicotPlatePipeline`) — output-contract pattern this pipeline mirrors.
+- **Unblocks**: #170 (`TimeDiffPipeline`) consuming tracked-tip per-track-over-time output. The plate-intra-series and tracked-tip-intra-series cases of #170 land cleanly once this pipeline ships.
+- **Substrate for**: future circumnutation pipeline (literature-driven design once assembled), future growth-rate / gravitropism pipelines.
+
+## Known limitations / follow-ups
+
+These are **explicit deferrals** filed as separate issues, NOT introduced by this PR:
+
+- **#186** — Per-frame metadata accessor on `Series` (`get_per_frame_metadata`, companion CSV). Required before any pipeline emits real-time-per-frame columns. This PR uses integer `frame` only.
+- **#187** — Preprocessing helpers (image folder → `.h5` + per-frame metadata CSV). Captures the upstream data-prep workflow.
+- **#188** — Generic source-META → sleap-roots-CSV converter. Captures the experiment-metadata side of data-prep. The fixture CSV in this PR is synthesized by hand pending this helper.
+- **#189** — Megafile split: refactor `trait_pipelines.py` into per-pipeline modules. This PR's `tracked_tip_pipeline.py` starts the pattern.
+- **`get_root_lengths` NaN-on-empty-segments behavior** — single-frame `tip_trajectory_length=NaN` is the codebase's existing convention. A future refactor could fix this (return 0.0) but would touch existing pipelines. Out of scope for #129. Documented in the spec.
+- **Pipeline class location follows new convention** — `sleap_roots/tracked_tip_pipeline.py`, NOT `sleap_roots/trait_pipelines.py`. Tests use both top-level (`from sleap_roots import TrackedTipPipeline`) and module-level imports.
+- **Track-order non-determinism across frames** — verified during brainstorm: frame 0 instances are `[track_0, 1, 2, 3, 4, 5]` but frame 1 is `[track_0, 3, 4, 2, 1, 5]`. `Series.get_tracked_tips` MUST iterate per-instance and read `inst.track.name` per instance — never rely on positional ordering. Codified as a regression test.
+- **Single-node skeleton support** — verified on the circumnutation fixture (`['r0']`). The `[-1]` slice convention from `tips.get_tips` works because `pts[:, -1, :]` of a `(n_inst, 1, 2)` array degenerates to `(n_inst, 0, :)` which IS the only point. Codified as a regression test using a multi-node-skeleton synthetic .slp alongside the single-node real fixture.

--- a/openspec/changes/add-tracked-tip-pipeline/specs/tracked-tip-pipeline/spec.md
+++ b/openspec/changes/add-tracked-tip-pipeline/specs/tracked-tip-pipeline/spec.md
@@ -1,0 +1,414 @@
+# tracked-tip-pipeline Specification — ADDED Requirements
+
+## ADDED Requirements
+
+### Requirement: `TrackedTipPipeline` SHALL live in its own module
+
+A new module `sleap_roots/tracked_tip_pipeline.py` MUST exist and MUST contain a `TrackedTipPipeline(Pipeline)` class. The class MUST be re-exported from `sleap_roots.__init__` at the top level. Implementation MUST NOT be appended to `sleap_roots/trait_pipelines.py`. The module starts the per-pipeline-file pattern; the existing megafile split for the 8 pre-existing pipelines is tracked separately in #189.
+
+#### Scenario: Top-level import works
+
+- **Given** a fresh Python session
+- **When** `from sleap_roots import TrackedTipPipeline` is executed
+- **Then** the import succeeds and `TrackedTipPipeline` is the class defined in `sleap_roots/tracked_tip_pipeline.py`
+
+#### Scenario: Module-level import works
+
+- **Given** a fresh Python session
+- **When** `from sleap_roots.tracked_tip_pipeline import TrackedTipPipeline` is executed
+- **Then** the import succeeds and resolves to the same class as the top-level import
+
+### Requirement: `Series.get_tracked_tips` SHALL extract long-format tracked-tip rows
+
+A new method `Series.get_tracked_tips(self, root_type: Optional[Literal["primary", "lateral", "crown"]] = None) -> pd.DataFrame` MUST be added to the `Series` class. Behavior:
+
+- The `root_type` argument selects which of `primary_path` / `lateral_path` / `crown_path` to read. When `root_type` is `None`, MUST auto-detect from whichever single path is populated; MUST raise `ValueError` mentioning the missing or ambiguous paths if zero or more than one is populated.
+- The method MUST return a `pd.DataFrame` with exactly the columns `["track_id", "frame", "tip_x", "tip_y"]` in that order.
+- The DataFrame MUST be sorted lexicographically by `(track_id, frame)`. Output index MUST be a clean range index (`reset_index(drop=True)`).
+- The `tip_x` and `tip_y` values MUST come from `inst.numpy()[-1]` for each instance — the LAST node of the skeleton, by SLEAP convention. This applies to single-node skeletons (e.g. `['r0']`) and multi-node skeletons (e.g. `['base', 'mid', 'tip']`) identically.
+- The method MUST iterate per-instance (not by stacking `inst.numpy()` arrays per frame). Tracker output does NOT preserve positional ordering across frames; the implementation MUST read `inst.track.name` per instance individually.
+- Untracked instances (`inst.track is None` or `inst.track.name` empty/None/falsy) MUST cause the method to raise `ValueError` whose message contains the offending frame index AND the URL `https://sleap.ai/tutorials/tracking.html` (or the closest supported sleap.ai documentation URL — whichever is canonical at the time).
+
+#### Scenario: Returns long-format DataFrame with expected columns
+
+- **Given** a `Series` loaded from a tracked .slp with 3 frames and 2 tracks (every instance tracked)
+- **When** `series.get_tracked_tips()` is called
+- **Then** the return value is a `pd.DataFrame` with columns `["track_id", "frame", "tip_x", "tip_y"]`
+- **And** `len(df) == 6` (one row per `(track_id, frame)` where the track has an instance)
+
+#### Scenario: Output is sorted by (track_id, frame)
+
+- **Given** a tracked .slp where instance positional order varies across frames (e.g. frame 0 is `[track_a, track_b]`, frame 1 is `[track_b, track_a]`)
+- **When** `series.get_tracked_tips()` is called
+- **Then** within each `track_id` group of the returned DataFrame, the `frame` column is monotonically non-decreasing
+- **And** `df.equals(df.sort_values(["track_id", "frame"]).reset_index(drop=True))` is `True`
+
+#### Scenario: Auto-detects root type when only primary_path is set
+
+- **Given** a `Series.load(primary_path=tracked_slp_path)` call (lateral_path and crown_path None)
+- **When** `series.get_tracked_tips()` is called WITHOUT a `root_type` argument
+- **Then** the method succeeds and reads from `primary_path`
+
+#### Scenario: Raises when multiple paths populated and no root_type
+
+- **Given** a `Series.load(primary_path=..., lateral_path=...)` call (both populated)
+- **When** `series.get_tracked_tips()` is called WITHOUT a `root_type` argument
+- **Then** `ValueError` is raised with a message mentioning `root_type` and listing the populated paths
+
+#### Scenario: Raises when zero paths populated
+
+- **Given** a `Series` with `primary_path=None`, `lateral_path=None`, `crown_path=None`
+- **When** `series.get_tracked_tips()` is called
+- **Then** `ValueError` is raised with a message mentioning `root_type` and the missing path kwargs
+
+#### Scenario: Raises on instance with `track is None`
+
+- **Given** a tracked .slp where one instance at frame 5 has `inst.track is None`
+- **When** `series.get_tracked_tips()` is called
+- **Then** `ValueError` is raised with a message containing `"5"` (the frame index) and `"sleap.ai/tutorials/tracking"`
+
+#### Scenario: Raises on instance with empty track name
+
+- **Given** a tracked .slp where one instance has `inst.track = sio.Track(name="")` (or `name=None`)
+- **When** `series.get_tracked_tips()` is called
+- **Then** `ValueError` is raised with the same message format as the `track is None` case (empty/None track name treated as untracked)
+
+#### Scenario: Single-node skeleton — tip is the only node
+
+- **Given** a tracked .slp whose skeleton has a single node (e.g. `['r0']`) and one tracked instance per frame
+- **When** `series.get_tracked_tips()` is called
+- **Then** the returned `tip_x` / `tip_y` values equal that single node's coordinates (`inst.numpy()[0]` and `inst.numpy()[-1]` are identical for a 1-node skeleton)
+
+#### Scenario: Multi-node skeleton — tip is the last node
+
+- **Given** a tracked .slp whose skeleton has 3 nodes named `['base', 'mid', 'tip']` and one tracked instance per frame
+- **When** `series.get_tracked_tips()` is called
+- **Then** the returned `tip_x` / `tip_y` values equal the LAST-node coordinates (`inst.numpy()[-1]`), NOT the base or mid coordinates
+
+### Requirement: `validate_tracked_slp` SHALL validate a .slp path
+
+A new module-level function `validate_tracked_slp(slp_path: Union[str, Path]) -> None` MUST be added to `sleap_roots/series.py` and re-exported from `sleap_roots.__init__`. The function MUST:
+
+- Open the .slp via `sio.load_slp`.
+- Walk every labeled frame and every instance.
+- Collect the frame indices of any frame containing an instance with `inst.track is None` or empty/None `inst.track.name`.
+- Return `None` if all instances are tracked.
+- Raise `ValueError` listing ALL offending frame indices in the message if any are untracked.
+
+#### Scenario: Returns None on fully-tracked .slp
+
+- **Given** a .slp where every instance has a non-empty `inst.track.name`
+- **When** `validate_tracked_slp(path)` is called
+- **Then** the return value is `None` and no exception is raised
+
+#### Scenario: Raises listing all offending frame indices
+
+- **Given** a .slp where instances at frame 2, frame 7, and frame 15 are untracked (others are tracked)
+- **When** `validate_tracked_slp(path)` is called
+- **Then** `ValueError` is raised
+- **And** the error message contains the strings `"2"`, `"7"`, and `"15"` (or a sorted/comma-separated representation thereof)
+
+### Requirement: `validate_series_for_tracked_tip` SHALL validate a Series instance
+
+A new module-level function `validate_series_for_tracked_tip(series: Series, root_type: Optional[str] = None) -> None` MUST be added to `sleap_roots/series.py` and re-exported. Behavior:
+
+- Resolve `root_type` (auto-detect from populated `<root_type>_path` when `None`); MUST raise `ValueError` on zero or >1 populated paths with the same wording as `Series.get_tracked_tips`.
+- Verify the resolved `<root_type>_labels` is loadable and the skeleton has at least one node; raise `ValueError` otherwise.
+- Call `validate_tracked_slp` on the resolved path; propagate any `ValueError` from there.
+
+#### Scenario: Resolves root_type and validates
+
+- **Given** a `Series.load(primary_path=tracked_slp_path)` (lateral and crown unset)
+- **When** `validate_series_for_tracked_tip(series)` is called WITHOUT `root_type`
+- **Then** the function returns `None` and no exception is raised
+
+#### Scenario: Explicit root_type validates the chosen path
+
+- **Given** a `Series.load(primary_path=tracked_slp_a, lateral_path=tracked_slp_b)` where BOTH .slp files are validly tracked
+- **When** `validate_series_for_tracked_tip(series, root_type="lateral")` is called
+- **Then** the function validates `tracked_slp_b` (the lateral path) and returns `None`
+- **And** calling with `root_type="primary"` validates `tracked_slp_a` and returns `None`
+
+### Requirement: `TrackedTipPipeline` SHALL define traits via DAG-A composition reusing existing trait functions
+
+The `TrackedTipPipeline.traits` list MUST contain TraitDef nodes that reuse existing trait functions DIRECTLY as `fn` values (no wrapper module). The DAG MUST provide per-track input slicing so existing functions plug in unchanged. Specifically:
+
+- A `track_first_xy` TraitDef with `fn=lambda xy: xy[0]` and `input_traits=["track_xy"]`.
+- A `track_last_xy` TraitDef with `fn=lambda xy: xy[-1]` and `input_traits=["track_xy"]`.
+- A `tip_displacement_net` TraitDef with `fn=sleap_roots.bases.get_base_tip_dist` (used directly, no wrapper) and `input_traits=["track_first_xy", "track_last_xy"]`.
+- A `tip_trajectory_length` TraitDef with `fn=sleap_roots.lengths.get_root_lengths` (used directly, no wrapper) and `input_traits=["track_xy"]`.
+- A `tracking_coverage` TraitDef with `fn=lambda nt, ntot: nt/ntot if ntot else np.nan` and `input_traits=["n_frames_tracked", "n_frames_total"]`.
+
+No new trait module (e.g. `tip_kinematics.py`) SHALL be created. The pipeline file `sleap_roots/tracked_tip_pipeline.py` itself holds the small lambdas inline in TraitDef definitions.
+
+#### Scenario: tip_displacement_net delegates to get_base_tip_dist
+
+- **Given** a `TrackedTipPipeline` instance and a single track with a 3-4-5-triangle trajectory `[(0,0), (3,0), (3,4)]`
+- **When** `compute_tracked_tip_traits(series)` is called
+- **Then** the per-track summary row's `tip_displacement_net == 5.0` (Euclidean distance from `(0,0)` to `(3,4)`, computed via `get_base_tip_dist`)
+- **And** `tip_trajectory_length == 7.0` (total path length 3 + 4)
+
+#### Scenario: tracking_coverage uses inline lambda
+
+- **Given** a track present in 3 of 5 total frames
+- **When** the pipeline computes the per-track summary
+- **Then** `tracking_coverage == 0.6`
+
+#### Scenario: No `tip_kinematics` module is created
+
+- **Given** the merged PR for this change
+- **When** `find sleap_roots -name 'tip_kinematics*'` is executed
+- **Then** no file matches (the module deliberately does not exist)
+
+### Requirement: `compute_tracked_tip_traits` SHALL emit a structured per-series result dict
+
+The `TrackedTipPipeline.compute_tracked_tip_traits(self, series, *, write_csv=False, write_json=False, output_dir=".", emit_trajectories=True, csv_summary_suffix=".tracked_tip_traits.csv", csv_trajectory_suffix=".tracked_tip_trajectories.csv", json_suffix=".tracked_tip_traits.json") -> Dict[str, Any]` method MUST return a dict with exactly these top-level keys:
+
+- `schema_version: int` — value `1` (initial schema version).
+- `pipeline: str` — value `"TrackedTipPipeline"`.
+- `units: Dict[str, str]` — value `{"lengths": "pixels", "ratios": "dimensionless", "counts": "dimensionless", "time": "unspecified"}`.
+- `series: str` — value of `series.series_name`.
+- `sample_uid: str` — value of `series.sample_uid` (defaults to `series_name` when no kwarg/CSV per Workstream 1).
+- `timepoint: Union[float, None]` — value of `series.timepoint` (NaN when no CSV; coerced to `null` in JSON via `_json_sanitize`).
+- `tracks: List[Dict[str, Any]]` — one entry per `track_id` (see next requirement).
+- `trajectories: List[Dict[str, Any]]` — one entry per `(track_id, frame)` (see next requirement). When `emit_trajectories=False`, this list MUST be `[]` (empty list — present for shape stability, NOT omitted from the dict).
+
+#### Scenario: Result dict has all top-level keys
+
+- **Given** a `TrackedTipPipeline` and a fully-tracked `Series` with 5 frames and 2 tracks
+- **When** `compute_tracked_tip_traits(series)` is called
+- **Then** the returned dict's `set(keys)` equals `{"schema_version", "pipeline", "units", "series", "sample_uid", "timepoint", "tracks", "trajectories"}`
+
+#### Scenario: Schema version is 1 for the initial release
+
+- **Given** the initial release of `TrackedTipPipeline`
+- **When** any `compute_tracked_tip_traits` call is made
+- **Then** `result["schema_version"] == 1`
+
+#### Scenario: Units dict has exactly the expected keys
+
+- **Given** any `compute_tracked_tip_traits` call
+- **Then** `result["units"] == {"lengths": "pixels", "ratios": "dimensionless", "counts": "dimensionless", "time": "unspecified"}`
+
+#### Scenario: emit_trajectories=False yields empty trajectories list
+
+- **Given** any compute call with `emit_trajectories=False`
+- **When** the result is inspected
+- **Then** `result["trajectories"] == []` (empty list, not missing key)
+- **And** `result["tracks"]` is unchanged from the `emit_trajectories=True` call
+
+### Requirement: `tracks` and `trajectories` rows SHALL have specified column sets
+
+Each entry in `result["tracks"]` MUST be a dict with exactly these keys: `track_id` (str), `n_frames_tracked` (int), `n_frames_total` (int), `tracking_coverage` (float), `tip_trajectory_length` (float), `tip_displacement_net` (float).
+
+Each entry in `result["trajectories"]` MUST be a dict with exactly these keys: `track_id` (str), `frame` (int), `tip_x` (float), `tip_y` (float).
+
+Top-level scalars (`series`, `sample_uid`, `timepoint`) MUST NOT be repeated in either per-row dict in JSON output. They MUST be repeated on every row in CSV output (PR #165's CSV/JSON asymmetry).
+
+#### Scenario: Per-track summary row has exact key set
+
+- **Given** any `compute_tracked_tip_traits` result
+- **And** a track with `track_id="track_0"`
+- **When** the row is selected from `result["tracks"]`
+- **Then** `set(row.keys()) == {"track_id", "n_frames_tracked", "n_frames_total", "tracking_coverage", "tip_trajectory_length", "tip_displacement_net"}`
+- **And** the row does NOT contain `series`, `sample_uid`, or `timepoint` keys
+
+#### Scenario: Per-frame trajectory row has exact key set
+
+- **Given** any `compute_tracked_tip_traits` result with `emit_trajectories=True`
+- **When** a row is selected from `result["trajectories"]`
+- **Then** `set(row.keys()) == {"track_id", "frame", "tip_x", "tip_y"}`
+- **And** the row does NOT contain `series`, `sample_uid`, or `timepoint` keys
+
+### Requirement: Single-frame edge case behavior is documented and asymmetric
+
+For a track present in exactly one frame, the per-track summary row MUST satisfy:
+
+- `n_frames_tracked == 1`.
+- `tracking_coverage > 0` (specifically `1 / n_frames_total`).
+- `tip_displacement_net == 0.0` — natural geometric result (xy[0] equals xy[-1]; `get_base_tip_dist` returns 0.0).
+- `tip_trajectory_length` is `NaN` (numpy `np.nan`) — `get_root_lengths`'s vacuous-truth NaN guard on empty-segment arrays. This asymmetry with `tip_displacement_net` is **intentional** — accepted as the trade-off for using the existing function directly via DAG composition without a wrapper. Users who want either filtered or coerced apply `fillna(0.0)` post-hoc; users who want only "real trajectories" filter on `n_frames_tracked > 1`.
+
+In JSON output, the `NaN` value MUST be serialized as `null` via `_json_sanitize` (existing helper from `trait_pipelines.py`).
+
+#### Scenario: Single-frame track has zero displacement
+
+- **Given** a synthetic .slp with one track that appears in exactly 1 of 10 frames
+- **When** `compute_tracked_tip_traits(series)` is called
+- **Then** the per-track summary row has `tip_displacement_net == 0.0`
+
+#### Scenario: Single-frame track has NaN trajectory length
+
+- **Given** the same .slp
+- **When** the result is inspected
+- **Then** `np.isnan(row["tip_trajectory_length"])` is `True`
+
+#### Scenario: Single-frame trajectory length serializes to JSON null
+
+- **Given** the same compute call with `write_json=True`
+- **When** the JSON file is parsed
+- **Then** the corresponding `tracks[i]["tip_trajectory_length"]` is JSON `null`
+
+### Requirement: Zero-track and zero-frame edge cases SHALL not crash
+
+When the input `Series` has no tracked instances anywhere (e.g. all instances were untracked and validation was skipped, or the .slp is empty), `compute_tracked_tip_traits` MUST return a result dict with `result["tracks"] == []` and `result["trajectories"] == []`. No exception is raised, no division-by-zero on `tracking_coverage` (the lambda's `if ntot else np.nan` guard handles `n_frames_total == 0`).
+
+This requirement is paired with the validate-on-input-required behavior: in the normal flow, `validate_series_for_tracked_tip` raises BEFORE the pipeline runs. The zero-track edge case is reachable only when the user explicitly bypasses validation OR when a .slp is empty (e.g. `sio.Labels(labeled_frames=[])`).
+
+#### Scenario: Empty .slp produces empty result
+
+- **Given** an empty `sio.Labels` saved to a .slp
+- **When** the user constructs `Series` and calls `compute_tracked_tip_traits` (bypassing validation)
+- **Then** `result["tracks"] == []` and `result["trajectories"] == []`
+- **And** no exception is raised
+
+### Requirement: CSV output SHALL emit two files per series
+
+When `compute_tracked_tip_traits(series, write_csv=True, output_dir=...)` is called, the method MUST write:
+
+- `<output_dir>/<series_name>.tracked_tip_traits.csv` — summary CSV. One row per `track_id`. Columns in order: `series, sample_uid, timepoint, track_id, n_frames_tracked, n_frames_total, tracking_coverage, tip_trajectory_length, tip_displacement_net`.
+- `<output_dir>/<series_name>.tracked_tip_trajectories.csv` — trajectory CSV. One row per `(track_id, frame)`. Columns in order: `series, sample_uid, timepoint, track_id, frame, tip_x, tip_y`. **NOT written when `emit_trajectories=False`.**
+
+The `series`, `sample_uid`, and `timepoint` values MUST be repeated on every row of both CSVs.
+
+#### Scenario: CSV files are written with expected names
+
+- **Given** a `Series` with `series_name="plate_001"` and a tmp output directory
+- **When** `compute_tracked_tip_traits(series, write_csv=True, output_dir=tmp_path)` is called
+- **Then** `tmp_path / "plate_001.tracked_tip_traits.csv"` exists
+- **And** `tmp_path / "plate_001.tracked_tip_trajectories.csv"` exists
+
+#### Scenario: Summary CSV column order is exact
+
+- **Given** the summary CSV from a successful compute call
+- **When** parsed via `pd.read_csv`
+- **Then** `list(df.columns) == ["series", "sample_uid", "timepoint", "track_id", "n_frames_tracked", "n_frames_total", "tracking_coverage", "tip_trajectory_length", "tip_displacement_net"]`
+
+#### Scenario: Trajectory CSV column order is exact
+
+- **Given** the trajectory CSV from a successful compute call
+- **When** parsed via `pd.read_csv`
+- **Then** `list(df.columns) == ["series", "sample_uid", "timepoint", "track_id", "frame", "tip_x", "tip_y"]`
+
+#### Scenario: emit_trajectories=False suppresses trajectory CSV
+
+- **Given** a compute call with `emit_trajectories=False, write_csv=True`
+- **When** the output directory is inspected
+- **Then** the summary CSV exists
+- **And** no trajectory CSV exists in `output_dir` for this series
+
+#### Scenario: CSV repeats top-level scalars on every row
+
+- **Given** a summary CSV from a 6-track series with `sample_uid="plate_001"` and `timepoint=0.0`
+- **When** parsed
+- **Then** every row has `series == "plate_001"` (or whatever `series_name` is), `sample_uid == "plate_001"`, `timepoint == 0.0`
+
+### Requirement: JSON output SHALL emit a single file per series with both tables
+
+When `compute_tracked_tip_traits(series, write_json=True, output_dir=...)` is called, the method MUST write `<output_dir>/<series_name>.tracked_tip_traits.json`. The JSON content MUST:
+
+- Be valid RFC-8259 JSON.
+- Have exactly the top-level keys `{"schema_version", "pipeline", "units", "series", "sample_uid", "timepoint", "tracks", "trajectories"}`.
+- Carry NaN values as JSON `null` (via `_json_sanitize`).
+- NOT repeat `series`, `sample_uid`, or `timepoint` inside `tracks[i]` or `trajectories[i]` rows.
+
+#### Scenario: JSON file is written with expected name
+
+- **Given** a `Series` with `series_name="plate_001"`
+- **When** `compute_tracked_tip_traits(series, write_json=True, output_dir=tmp_path)` is called
+- **Then** `tmp_path / "plate_001.tracked_tip_traits.json"` exists and is valid JSON
+
+#### Scenario: JSON top-level scalars are present once
+
+- **Given** the JSON from a 6-track series
+- **When** parsed
+- **Then** the top-level dict has `series`, `sample_uid`, `timepoint` keys
+- **And** none of the `tracks[i]` or `trajectories[i]` row dicts contain those keys
+
+#### Scenario: JSON validates as RFC-8259 with NaN sanitized
+
+- **Given** any compute call where some scalars are `NaN`
+- **When** the JSON file is read with `json.load(...)` (Python's stdlib parser using default settings)
+- **Then** the call succeeds (no `JSONDecodeError`)
+- **And** the NaN values appear as Python `None` (JSON `null`)
+
+### Requirement: `compute_batch_tracked_tip_traits` SHALL concatenate per-series results
+
+`TrackedTipPipeline.compute_batch_tracked_tip_traits(self, all_series, *, write_csv=False, write_json=False, output_dir=".", csv_summary_name="tracked_tip_batch_traits.csv", csv_trajectory_name="tracked_tip_batch_trajectories.csv", json_name="tracked_tip_batch_traits.json", emit_trajectories=True) -> Tuple[pd.DataFrame, Optional[pd.DataFrame], List[Dict[str, Any]]]` MUST:
+
+- Walk `all_series` and call `compute_tracked_tip_traits(series)` per series.
+- Concatenate per-series summary DataFrames into one DataFrame written to `<output_dir>/tracked_tip_batch_traits.csv` when `write_csv=True`.
+- Concatenate per-series trajectory DataFrames into one DataFrame written to `<output_dir>/tracked_tip_batch_trajectories.csv` when `write_csv=True` AND `emit_trajectories=True`.
+- Write the per-series result-dict list to `<output_dir>/tracked_tip_batch_traits.json` when `write_json=True` (the JSON content is a JSON array of per-series dicts, NOT a single combined dict).
+- Return the concatenated summary DataFrame, the concatenated trajectory DataFrame (or `None` when `emit_trajectories=False`), and the list of per-series result dicts.
+
+This MUST mirror the existing pattern in [trait_pipelines.py:3327](sleap_roots/trait_pipelines.py#L3327) (`compute_batch_plate_traits`).
+
+#### Scenario: Batch summary CSV concatenates rows across series
+
+- **Given** 3 synthetic `Series`, each with 2 tracked tracks
+- **When** `compute_batch_tracked_tip_traits(all_series, write_csv=True)` is called
+- **Then** `tracked_tip_batch_traits.csv` has 6 rows total (2 tracks × 3 series)
+
+#### Scenario: Batch trajectory CSV concatenates rows across series
+
+- **Given** the same 3 series, each with 5 frames × 2 fully-tracked tracks
+- **When** the same call is made
+- **Then** `tracked_tip_batch_trajectories.csv` has 30 rows total (10 per series × 3 series)
+
+#### Scenario: Batch JSON is a list of per-series dicts
+
+- **Given** the same call with `write_json=True`
+- **When** the JSON is parsed
+- **Then** the parsed value is a Python `list` of length 3
+- **And** each list element is shaped like a single `compute_tracked_tip_traits` output dict (same key set)
+
+#### Scenario: Empty input list yields empty outputs
+
+- **Given** `compute_batch_tracked_tip_traits([])` with all write flags `True`
+- **When** the call returns
+- **Then** the returned summary DataFrame is empty
+- **And** the JSON file (if written) parses to `[]` (empty list)
+- **And** no exception is raised
+
+#### Scenario: emit_trajectories=False suppresses batch trajectory CSV
+
+- **Given** a batch call with `emit_trajectories=False, write_csv=True`
+- **When** the output directory is inspected
+- **Then** `tracked_tip_batch_traits.csv` exists
+- **And** `tracked_tip_batch_trajectories.csv` does NOT exist
+
+### Requirement: Real-fixture integration tests SHALL ship with the change
+
+A real-data fixture MUST be committed under `tests/data/circumnutation_plate/` containing:
+
+- `plate_001_greyscale.tracked.slp` — 184 KB tracked predictions, sliced from the source data on `Z:\users\eberrigan\circumnutation\...\run_20250827_091833\plate_001_greyscale.tracked.slp` (provenance documented in README). Committed via Git LFS.
+- `fixture_metadata.csv` — synthesized plate-level metadata, single row, `plant_qr_code="plate_001"`, columns `[plant_qr_code, genotype, treatment, number_of_plants_cylinder, timepoint]`.
+- `README.md` — documentation per the standard template (issue #168), covering provenance, conversion steps, the `plant_qr_code` legacy-name caveat, and the deferral of per-frame metadata to #186.
+
+Two integration tests MUST exist:
+
+1. WITH `csv_path`: asserts `result["sample_uid"] == "plate_001"`, `result["timepoint"] == 0.0`, `len(result["tracks"]) == 6`, `len(result["trajectories"]) == 1866`, every `tracking_coverage ∈ [0, 1]`.
+2. WITHOUT `csv_path`: same series, same pipeline call, asserts `result["sample_uid"]` defaults to `series_name`, `np.isnan(result["timepoint"])`, all numeric trait values match path 1.
+
+#### Scenario: Real fixture loads and produces expected track count
+
+- **Given** the committed fixture .slp at `tests/data/circumnutation_plate/plate_001_greyscale.tracked.slp`
+- **When** loaded via `Series.load(primary_path=..., csv_path=fixture_metadata_path, sample_uid="plate_001")` and processed by `TrackedTipPipeline().compute_tracked_tip_traits(series)`
+- **Then** `len(result["tracks"]) == 6`
+- **And** every `track["tracking_coverage"]` is in `[0.0, 1.0]`
+- **And** `len(result["trajectories"]) == 1866`
+
+#### Scenario: No-CSV path defaults sample_uid and timepoint
+
+- **Given** the same fixture .slp loaded WITHOUT `csv_path`
+- **When** `compute_tracked_tip_traits(series)` is called
+- **Then** `result["sample_uid"] == series.series_name`
+- **And** `np.isnan(result["timepoint"])`
+- **And** every numeric trait value matches the corresponding row in the WITH-CSV scenario (only the metadata changes, not the geometry)
+
+#### Scenario: Track names are the brainstorm-verified track_0 .. track_5
+
+- **Given** the real fixture
+- **When** `compute_tracked_tip_traits(series)` is called
+- **Then** `set(row["track_id"] for row in result["tracks"]) == {"track_0", "track_1", "track_2", "track_3", "track_4", "track_5"}`

--- a/openspec/changes/add-tracked-tip-pipeline/specs/tracked-tip-pipeline/spec.md
+++ b/openspec/changes/add-tracked-tip-pipeline/specs/tracked-tip-pipeline/spec.md
@@ -249,6 +249,29 @@ In JSON output, the `NaN` value MUST be serialized as `null` via `_json_sanitize
 - **When** the JSON file is parsed
 - **Then** the corresponding `tracks[i]["tip_trajectory_length"]` is JSON `null`
 
+### Requirement: `tracking_coverage` SHALL be bounded to `[0.0, 1.0]` regardless of duplicate `(track_id, frame)` rows
+
+`tracking_coverage` MUST be a float in `[0.0, 1.0]` for every track in the result. To enforce this bound, `n_frames_tracked` MUST equal the number of UNIQUE frame indices in which the track has an instance — NOT the raw count of instances. Pathological tracker output (e.g. merged tracks producing two instances with the same `track_id` in the same frame) MUST NOT inflate `tracking_coverage` above `1.0`.
+
+Implementation: in `compute_tracked_tip_traits`'s per-track groupby, `n_frames_tracked = int(group["frame"].nunique())` (NOT `len(group)`). This deduplicates duplicate `(track_id, frame)` rows from the trajectory DataFrame before computing the coverage ratio.
+
+Note: this requirement specifies the OUTPUT contract on `n_frames_tracked` and `tracking_coverage`. The trajectory CSV still records every row from `Series.get_tracked_tips` (one per tracked instance), so duplicate `(track_id, frame)` instances remain visible in the per-frame trajectory table for downstream debugging. Only the per-track summary row's `n_frames_tracked` and the derived `tracking_coverage` are deduplicated.
+
+#### Scenario: Duplicate `(track_id, frame)` does not inflate tracking_coverage above 1.0
+
+- **Given** a synthetic .slp with 1 frame containing 2 instances of the same `track_id="t"` (a buggy-tracker pathology — over-eager merger producing two coincident detections under one track id)
+- **When** `compute_tracked_tip_traits(series)` is called
+- **Then** the per-track summary row for `track_id="t"` has `tracking_coverage == 1.0` (`1 unique frame / 1 total frame`), NOT `2.0`
+- **And** `n_frames_tracked == 1` (the unique-frame count)
+- **And** `n_frames_total == 1`
+
+#### Scenario: Duplicate instances appear in trajectory rows but not inflate summary
+
+- **Given** the same .slp
+- **When** the result is inspected
+- **Then** `len(result["trajectories"])` reflects every tracked-instance row (including the duplicate — so `2` for a frame with two same-track instances)
+- **And** `n_frames_tracked` in the summary row is the deduplicated count (`1`, not `2`)
+
 ### Requirement: Zero-track and zero-frame edge cases SHALL not crash
 
 When the input `Series` has no tracked instances anywhere (e.g. all instances were untracked and validation was skipped, or the .slp is empty), `compute_tracked_tip_traits` MUST return a result dict with `result["tracks"] == []` and `result["trajectories"] == []`. No exception is raised, no division-by-zero on `tracking_coverage` (the lambda's `if ntot else np.nan` guard handles `n_frames_total == 0`).

--- a/openspec/changes/add-tracked-tip-pipeline/specs/tracked-tip-pipeline/spec.md
+++ b/openspec/changes/add-tracked-tip-pipeline/specs/tracked-tip-pipeline/spec.md
@@ -249,6 +249,25 @@ In JSON output, the `NaN` value MUST be serialized as `null` via `_json_sanitize
 - **When** the JSON file is parsed
 - **Then** the corresponding `tracks[i]["tip_trajectory_length"]` is JSON `null`
 
+### Requirement: `TrackedTipPipeline` TraitDef `fn` values SHALL be picklable
+
+Every `TraitDef` returned by `TrackedTipPipeline.define_traits()` MUST have a `fn` value that is picklable via the standard library `pickle` module. Inline lambdas (which are not picklable by default) MUST NOT be used — TraitDef functions MUST be either references to module-level functions or references to imported callables (e.g. `bases.get_base_tip_dist`).
+
+Rationale: this is a precondition for any future `multiprocessing`-based parallelization of the trait DAG. The DAG is currently executed serially; a future change that distributes trait computation across processes (or uses `joblib.Parallel` with the loky backend) requires every trait function to round-trip through pickle. Inline lambdas in TraitDef definitions silently block that future refactor.
+
+#### Scenario: TrackedTipPipeline traits list pickles cleanly
+
+- **Given** a `TrackedTipPipeline()` instance
+- **When** `pickle.dumps(pipeline.traits)` is called
+- **Then** the call succeeds and returns a non-empty `bytes` object
+- **And** `pickle.loads(...)` round-trips the trait list back to an equal-shape list of `TraitDef` objects with the same names and (callable) `fn` references
+
+#### Scenario: Each TraitDef.fn value individually pickles cleanly
+
+- **Given** a `TrackedTipPipeline()` instance
+- **When** for each `trait_def` in `pipeline.traits`, `pickle.dumps(trait_def.fn)` is called
+- **Then** every call succeeds and returns a non-empty `bytes` object
+
 ### Requirement: `tracking_coverage` SHALL be bounded to `[0.0, 1.0]` regardless of duplicate `(track_id, frame)` rows
 
 `tracking_coverage` MUST be a float in `[0.0, 1.0]` for every track in the result. To enforce this bound, `n_frames_tracked` MUST equal the number of UNIQUE frame indices in which the track has an instance — NOT the raw count of instances. Pathological tracker output (e.g. merged tracks producing two instances with the same `track_id` in the same frame) MUST NOT inflate `tracking_coverage` above `1.0`.

--- a/openspec/changes/add-tracked-tip-pipeline/tasks.md
+++ b/openspec/changes/add-tracked-tip-pipeline/tasks.md
@@ -13,16 +13,16 @@
 
 This lands FIRST because the integration tests in §11 depend on it. No Python code yet — just commit the fixture files so `git lfs ls-files` shows them tracked.
 
-- [ ] 1.1 Verify Git LFS hooks installed: `git lfs ls-files | head -3` shows existing `.slp` / `.h5` files in `tests/data/`. If not, install with `git lfs install`.
-- [ ] 1.2 Confirm `*.slp` is already tracked by LFS: `git check-attr -a tests/data/multiple_arabidopsis_11do/6039_1.primary.predictions.slp` shows `filter: lfs`. If not, fix `.gitattributes` first.
-- [ ] 1.3 Create `tests/data/circumnutation_plate/` directory.
-- [ ] 1.4 Copy `Z:\users\eberrigan\circumnutation\20250819_Suyash_Patil_CMTN_Kitx_vs_Hk1-3_07-30-25\run_20250827_091833\plate_001_greyscale.tracked.slp` → `tests/data/circumnutation_plate/plate_001_greyscale.tracked.slp` (184 KB).
-- [ ] 1.5 Synthesize `tests/data/circumnutation_plate/fixture_metadata.csv` with one row:
+- [x] 1.1 Verify Git LFS hooks installed: `git lfs ls-files | head -3` shows existing `.slp` / `.h5` files in `tests/data/`. If not, install with `git lfs install`.
+- [x] 1.2 Confirm `*.slp` is already tracked by LFS: `git check-attr -a tests/data/multiple_arabidopsis_11do/6039_1.primary.predictions.slp` shows `filter: lfs`. If not, fix `.gitattributes` first.
+- [x] 1.3 Create `tests/data/circumnutation_plate/` directory.
+- [x] 1.4 Copy `Z:\users\eberrigan\circumnutation\20250819_Suyash_Patil_CMTN_Kitx_vs_Hk1-3_07-30-25\run_20250827_091833\plate_001_greyscale.tracked.slp` → `tests/data/circumnutation_plate/plate_001_greyscale.tracked.slp` (184 KB).
+- [x] 1.5 Synthesize `tests/data/circumnutation_plate/fixture_metadata.csv` with one row:
   ```
   plant_qr_code,genotype,treatment,number_of_plants_cylinder,timepoint
   plate_001,KitaakeX,MOCK,6,0
   ```
-- [ ] 1.6 Write `tests/data/circumnutation_plate/README.md` per the standard template (issue #168). Required sections:
+- [x] 1.6 Write `tests/data/circumnutation_plate/README.md` per the standard template (issue #168). Required sections:
   - Purpose (input fixture for `TrackedTipPipeline` integration tests)
   - Imaging geometry (plate, 6 plants, ~5h imaging at ~10-min intervals — derived from filename datetime stamps)
   - Acquisition context (Suyash Patil, KitaakeX vs hk1-3, MOCK treatment, 2025-07-30)
@@ -30,84 +30,84 @@ This lands FIRST because the integration tests in §11 depend on it. No Python c
   - Conversion provenance (which source file mapped to which fixture file; what columns were renamed/dropped)
   - Known limitations (per-frame CSV NOT shipped — deferred to #186; column-name caveat — `plant_qr_code` value `"plate_001"` is a plate identifier, NOT a plant identifier, legacy convention; #163 will rename)
   - Related issues (#129, #163, #168, #186, #187, #188)
-- [ ] 1.7 `git add tests/data/circumnutation_plate/` and verify `git status` shows the .slp as `LFS`. Commit: `git commit -m "tests: add circumnutation_plate fixture for TrackedTipPipeline (#129)"`. DO NOT push until the PR is opened.
+- [x] 1.7 `git add tests/data/circumnutation_plate/` and verify `git status` shows the .slp as `LFS`. Commit: `git commit -m "tests: add circumnutation_plate fixture for TrackedTipPipeline (#129)"`. DO NOT push until the PR is opened.
 
 ## 2. Write failing tests for `Series.get_tracked_tips` (TDD red phase 1)
 
 These tests come FIRST — `get_tracked_tips` is the substrate accessor on which the pipeline + every downstream consumer depends.
 
-- [ ] 2.1 Locate or extend a synthetic-`.slp`-builder helper in `tests/conftest.py` or `tests/test_series.py` that constructs a tracked `.slp` via `sio.save_slp(...)` with `sio.Track` objects attached to instances via `inst.track = sio.Track(name="track_N")`. **Critical**: this helper accepts `n_frames`, `n_tracks`, `track_positions` (per-frame, per-track xy), `skeleton_node_names` (default `["r0"]` for single-node, configurable for multi-node), and `instance_order` (per-frame list of track names — supports the regression test for non-deterministic positional ordering across frames).
-- [ ] 2.2 Add `test_get_tracked_tips_returns_long_dataframe` — synthetic 3-frame .slp with 2 tracks → DataFrame with columns `["track_id", "frame", "tip_x", "tip_y"]`, 6 rows total.
-- [ ] 2.3 Add `test_get_tracked_tips_sorted_by_track_then_frame` — synthetic 3-frame .slp where instance positional order is RANDOMIZED per frame (frame 0: `[track_a, track_b]`; frame 1: `[track_b, track_a]`) → output DataFrame's `(track_id, frame)` column is monotonically sorted within each track group. **This is the regression test for the brainstorm-verified track-order non-determinism.**
-- [ ] 2.4 Add `test_get_tracked_tips_auto_detects_root_type_from_populated_path` — `Series.load(primary_path=...)` (lateral/crown empty) → `series.get_tracked_tips()` (no kwarg) succeeds and reads from primary.
-- [ ] 2.5 Add `test_get_tracked_tips_raises_when_multiple_paths_populated_no_root_type` — `Series.load(primary_path=..., lateral_path=...)` → `series.get_tracked_tips()` raises `ValueError` mentioning `root_type`.
-- [ ] 2.6 Add `test_get_tracked_tips_raises_when_zero_paths_populated` — `Series.load()` (none populated) → `ValueError` mentioning `root_type` and the missing path kwargs.
-- [ ] 2.7 Add `test_get_tracked_tips_raises_on_untracked_instance` — synthetic .slp where one instance has `inst.track = None` → `ValueError` mentioning the offending frame index AND `sleap.ai/tracking`.
-- [ ] 2.8 Add `test_get_tracked_tips_raises_on_empty_track_name` — synthetic .slp where `inst.track = sio.Track(name="")` → same `ValueError` as 2.7 (empty-name treated as untracked).
-- [ ] 2.9 Add `test_get_tracked_tips_single_node_skeleton` — synthetic .slp with skeleton `['r0']` (one node) → output `tip_x`, `tip_y` are the node's coordinates (`pts[-1]` is `pts[0]`).
-- [ ] 2.10 Add `test_get_tracked_tips_multi_node_skeleton` — synthetic .slp with skeleton `['base', 'mid', 'tip']` → output `tip_x`, `tip_y` are the LAST node's coordinates (the convention).
-- [ ] 2.11 Run `uv run pytest tests/test_series.py -k get_tracked_tips -x` — all 9 FAIL with `AttributeError: 'Series' object has no attribute 'get_tracked_tips'`.
+- [x] 2.1 Locate or extend a synthetic-`.slp`-builder helper in `tests/conftest.py` or `tests/test_series.py` that constructs a tracked `.slp` via `sio.save_slp(...)` with `sio.Track` objects attached to instances via `inst.track = sio.Track(name="track_N")`. **Critical**: this helper accepts `n_frames`, `n_tracks`, `track_positions` (per-frame, per-track xy), `skeleton_node_names` (default `["r0"]` for single-node, configurable for multi-node), and `instance_order` (per-frame list of track names — supports the regression test for non-deterministic positional ordering across frames).
+- [x] 2.2 Add `test_get_tracked_tips_returns_long_dataframe` — synthetic 3-frame .slp with 2 tracks → DataFrame with columns `["track_id", "frame", "tip_x", "tip_y"]`, 6 rows total.
+- [x] 2.3 Add `test_get_tracked_tips_sorted_by_track_then_frame` — synthetic 3-frame .slp where instance positional order is RANDOMIZED per frame (frame 0: `[track_a, track_b]`; frame 1: `[track_b, track_a]`) → output DataFrame's `(track_id, frame)` column is monotonically sorted within each track group. **This is the regression test for the brainstorm-verified track-order non-determinism.**
+- [x] 2.4 Add `test_get_tracked_tips_auto_detects_root_type_from_populated_path` — `Series.load(primary_path=...)` (lateral/crown empty) → `series.get_tracked_tips()` (no kwarg) succeeds and reads from primary.
+- [x] 2.5 Add `test_get_tracked_tips_raises_when_multiple_paths_populated_no_root_type` — `Series.load(primary_path=..., lateral_path=...)` → `series.get_tracked_tips()` raises `ValueError` mentioning `root_type`.
+- [x] 2.6 Add `test_get_tracked_tips_raises_when_zero_paths_populated` — `Series.load()` (none populated) → `ValueError` mentioning `root_type` and the missing path kwargs.
+- [x] 2.7 Add `test_get_tracked_tips_raises_on_untracked_instance` — synthetic .slp where one instance has `inst.track = None` → `ValueError` mentioning the offending frame index AND `sleap.ai/tracking`.
+- [x] 2.8 Add `test_get_tracked_tips_raises_on_empty_track_name` — synthetic .slp where `inst.track = sio.Track(name="")` → same `ValueError` as 2.7 (empty-name treated as untracked).
+- [x] 2.9 Add `test_get_tracked_tips_single_node_skeleton` — synthetic .slp with skeleton `['r0']` (one node) → output `tip_x`, `tip_y` are the node's coordinates (`pts[-1]` is `pts[0]`).
+- [x] 2.10 Add `test_get_tracked_tips_multi_node_skeleton` — synthetic .slp with skeleton `['base', 'mid', 'tip']` → output `tip_x`, `tip_y` are the LAST node's coordinates (the convention).
+- [x] 2.11 Run `uv run pytest tests/test_series.py -k get_tracked_tips -x` — all 9 FAIL with `AttributeError: 'Series' object has no attribute 'get_tracked_tips'`.
 
 ## 3. Implement `Series.get_tracked_tips` (TDD green phase 1)
 
-- [ ] 3.1 Add `get_tracked_tips(self, root_type: Optional[Literal["primary", "lateral", "crown"]] = None) -> pd.DataFrame` method to `Series` class in `sleap_roots/series.py`. Implementation:
+- [x] 3.1 Add `get_tracked_tips(self, root_type: Optional[Literal["primary", "lateral", "crown"]] = None) -> pd.DataFrame` method to `Series` class in `sleap_roots/series.py`. Implementation:
   - Resolve `root_type` (auto-detect when `None`); raise `ValueError` on zero / >1 populated paths.
   - Get the labels object for the resolved root type (`self.primary_labels` / `self.lateral_labels` / `self.crown_labels`).
   - Iterate `for frame_idx in range(len(labels)):` then `for inst in labels[frame_idx].instances:`. Note: existing accessors use `lf.user_instances + lf.unused_predictions` — confirm whether this matches what we want for tracked predictions (see open question in §3.4).
   - For each instance: assert `inst.track is not None and inst.track.name`; raise `ValueError` listing offending frame index + `sleap.ai/tracking` URL otherwise.
   - Append row dict `{"track_id": inst.track.name, "frame": frame_idx, "tip_x": inst.numpy()[-1, 0], "tip_y": inst.numpy()[-1, 1]}`.
   - Return `pd.DataFrame(rows).sort_values(["track_id", "frame"]).reset_index(drop=True)`.
-- [ ] 3.2 Update `Series` class docstring to mention `get_tracked_tips`. Add Google-style docstring to the new method covering Args / Returns / Raises.
-- [ ] 3.3 Verify via `uv run pytest tests/test_series.py -k get_tracked_tips -v` — all 9 pass.
-- [ ] 3.4 **Open question for code review**: which instance set to iterate — `lf.instances` (all), `lf.predicted_instances`, or `lf.user_instances + lf.unused_predictions` (existing convention)? Verify on the real fixture: `uv run --no-project python -c "import sleap_io as sio; lbls = sio.load_slp(r'tests/data/circumnutation_plate/plate_001_greyscale.tracked.slp'); print(len(lbls.labeled_frames[0].instances), len(lbls.labeled_frames[0].predicted_instances), len(lbls.labeled_frames[0].user_instances))"`. Document the choice in the docstring.
-- [ ] 3.5 Run `uv run pytest tests/ -x` — full suite green (no regressions on existing accessors).
+- [x] 3.2 Update `Series` class docstring to mention `get_tracked_tips`. Add Google-style docstring to the new method covering Args / Returns / Raises.
+- [x] 3.3 Verify via `uv run pytest tests/test_series.py -k get_tracked_tips -v` — all 9 pass.
+- [x] 3.4 **Open question for code review**: which instance set to iterate — `lf.instances` (all), `lf.predicted_instances`, or `lf.user_instances + lf.unused_predictions` (existing convention)? Verify on the real fixture: `uv run --no-project python -c "import sleap_io as sio; lbls = sio.load_slp(r'tests/data/circumnutation_plate/plate_001_greyscale.tracked.slp'); print(len(lbls.labeled_frames[0].instances), len(lbls.labeled_frames[0].predicted_instances), len(lbls.labeled_frames[0].user_instances))"`. Document the choice in the docstring.
+- [x] 3.5 Run `uv run pytest tests/ -x` — full suite green (no regressions on existing accessors).
 
 ## 4. Write failing tests for `validate_tracked_slp` + `validate_series_for_tracked_tip` (TDD red phase 2)
 
-- [ ] 4.1 Add `test_validate_tracked_slp_passes_on_fully_tracked` — synthetic .slp where every instance has `inst.track is not None` → `validate_tracked_slp(path)` returns `None`, no raise.
-- [ ] 4.2 Add `test_validate_tracked_slp_raises_on_untracked_instance` — synthetic .slp with one untracked instance → `ValueError` listing the offending frame index AND `sleap.ai/tracking`.
-- [ ] 4.3 Add `test_validate_tracked_slp_lists_all_offending_frames` — synthetic .slp with 3 untracked instances across 3 different frames → error message lists all 3 frame indices.
-- [ ] 4.4 Add `test_validate_series_for_tracked_tip_resolves_root_type` — `Series.load(primary_path=tracked_slp)` → `validate_series_for_tracked_tip(series)` (no `root_type`) succeeds.
-- [ ] 4.5 Add `test_validate_series_for_tracked_tip_explicit_root_type` — `Series.load(primary_path=tracked_slp, lateral_path=other_tracked)` → `validate_series_for_tracked_tip(series, root_type="primary")` succeeds; `root_type="lateral"` validates the other path.
-- [ ] 4.6 Add `test_validate_series_for_tracked_tip_raises_on_zero_or_multiple_paths_no_root_type` — same pattern as `get_tracked_tips` errors.
-- [ ] 4.7 Run `uv run pytest tests/test_series.py -k validate -x` — all 6 FAIL with `ImportError` (functions don't exist yet).
+- [x] 4.1 Add `test_validate_tracked_slp_passes_on_fully_tracked` — synthetic .slp where every instance has `inst.track is not None` → `validate_tracked_slp(path)` returns `None`, no raise.
+- [x] 4.2 Add `test_validate_tracked_slp_raises_on_untracked_instance` — synthetic .slp with one untracked instance → `ValueError` listing the offending frame index AND `sleap.ai/tracking`.
+- [x] 4.3 Add `test_validate_tracked_slp_lists_all_offending_frames` — synthetic .slp with 3 untracked instances across 3 different frames → error message lists all 3 frame indices.
+- [x] 4.4 Add `test_validate_series_for_tracked_tip_resolves_root_type` — `Series.load(primary_path=tracked_slp)` → `validate_series_for_tracked_tip(series)` (no `root_type`) succeeds.
+- [x] 4.5 Add `test_validate_series_for_tracked_tip_explicit_root_type` — `Series.load(primary_path=tracked_slp, lateral_path=other_tracked)` → `validate_series_for_tracked_tip(series, root_type="primary")` succeeds; `root_type="lateral"` validates the other path.
+- [x] 4.6 Add `test_validate_series_for_tracked_tip_raises_on_zero_or_multiple_paths_no_root_type` — same pattern as `get_tracked_tips` errors.
+- [x] 4.7 Run `uv run pytest tests/test_series.py -k validate -x` — all 6 FAIL with `ImportError` (functions don't exist yet).
 
 ## 5. Implement `validate_tracked_slp` + `validate_series_for_tracked_tip` (TDD green phase 2)
 
-- [ ] 5.1 Add `validate_tracked_slp(slp_path: Union[str, Path]) -> None` as a module-level function in `sleap_roots/series.py` (NOT a method on `Series` — it operates on a path string before any `Series` is constructed). Implementation: open via `sio.load_slp`, walk frames + instances, collect frames with any untracked instance, raise `ValueError` if any.
-- [ ] 5.2 Add `validate_series_for_tracked_tip(series: Series, root_type: Optional[str] = None) -> None` as a module-level function. Implementation: resolve root_type, check the relevant `<root_type>_path` attribute is set, assert skeleton has ≥1 node, call `validate_tracked_slp` on the resolved path.
-- [ ] 5.3 Re-export both from `sleap_roots/__init__.py`.
-- [ ] 5.4 Run `uv run pytest tests/test_series.py -k validate -v` — all 6 pass.
-- [ ] 5.5 Run `uv run pytest tests/ -x` — full suite green.
+- [x] 5.1 Add `validate_tracked_slp(slp_path: Union[str, Path]) -> None` as a module-level function in `sleap_roots/series.py` (NOT a method on `Series` — it operates on a path string before any `Series` is constructed). Implementation: open via `sio.load_slp`, walk frames + instances, collect frames with any untracked instance, raise `ValueError` if any.
+- [x] 5.2 Add `validate_series_for_tracked_tip(series: Series, root_type: Optional[str] = None) -> None` as a module-level function. Implementation: resolve root_type, check the relevant `<root_type>_path` attribute is set, assert skeleton has ≥1 node, call `validate_tracked_slp` on the resolved path.
+- [x] 5.3 Re-export both from `sleap_roots/__init__.py`.
+- [x] 5.4 Run `uv run pytest tests/test_series.py -k validate -v` — all 6 pass.
+- [x] 5.5 Run `uv run pytest tests/ -x` — full suite green.
 
 ## 6. Write failing tests for `TrackedTipPipeline` DAG composition (TDD red phase 3)
 
 These tests exercise the pipeline class without writing files — pure compute method, in-memory result dict.
 
-- [ ] 6.1 Create `tests/test_tracked_tip_pipeline.py`. Add a synthetic-`.slp`-builder helper or import from conftest.
-- [ ] 6.2 Add `test_compute_tracked_tip_traits_returns_expected_dict_keys` — synthetic 5-frame .slp with 2 tracks → result dict has top-level keys `{schema_version, pipeline, units, series, sample_uid, timepoint, tracks, trajectories}`.
-- [ ] 6.3 Add `test_compute_tracked_tip_traits_schema_version_is_1` — `result["schema_version"] == 1`.
-- [ ] 6.4 Add `test_compute_tracked_tip_traits_units_dict` — `result["units"] == {"lengths": "pixels", "ratios": "dimensionless", "counts": "dimensionless", "time": "unspecified"}`.
-- [ ] 6.5 Add `test_compute_tracked_tip_traits_tracks_table_one_row_per_track_id` — synthetic 2-track .slp → `len(result["tracks"]) == 2`. Each row has keys `{track_id, n_frames_tracked, n_frames_total, tracking_coverage, tip_trajectory_length, tip_displacement_net}`.
-- [ ] 6.6 Add `test_compute_tracked_tip_traits_trajectories_table_one_row_per_track_frame` — synthetic 5-frame × 2-track .slp where every instance is tracked → `len(result["trajectories"]) == 10`.
-- [ ] 6.7 Add `test_tip_trajectory_length_straight_line` — synthetic .slp where one track moves in a straight line of known length (e.g. (0,0) → (3,0) → (6,0) → (10,0)) → `tip_trajectory_length == 10.0`.
-- [ ] 6.8 Add `test_tip_displacement_net_straight_line` — same straight-line track → `tip_displacement_net == 10.0`.
-- [ ] 6.9 Add `test_tip_displacement_net_round_trip_returns_to_origin` — track (0,0) → (5,0) → (0,0) → `tip_displacement_net == 0.0`, `tip_trajectory_length == 10.0`. **Validates the geometric distinction.**
-- [ ] 6.10 Add `test_tip_displacement_net_right_angle_path` — track (0,0) → (3,0) → (3,4) → `tip_trajectory_length == 7.0`, `tip_displacement_net == 5.0` (3-4-5 triangle).
-- [ ] 6.11 Add `test_tracking_coverage_full` — every frame tracked → `tracking_coverage == 1.0`.
-- [ ] 6.12 Add `test_tracking_coverage_partial` — track present in 3 of 5 frames → `tracking_coverage == 0.6`.
-- [ ] 6.13 Add `test_compute_tracked_tip_traits_single_frame_track_zero_displacement_nan_length` — track present in 1 frame only → `tip_displacement_net == 0.0`, `np.isnan(tip_trajectory_length)`, `n_frames_tracked == 1`. **Codifies the documented asymmetry.**
-- [ ] 6.14 Add `test_compute_tracked_tip_traits_zero_tracks` — synthetic .slp with NO tracked instances anywhere → `len(result["tracks"]) == 0`, `len(result["trajectories"]) == 0`, no crash.
-- [ ] 6.15 Add `test_compute_tracked_tip_traits_emits_sample_uid_and_timepoint_from_csv` — `Series.load(primary_path=..., csv_path=metadata_csv, sample_uid="plate_X")` where the CSV has a row with `plant_qr_code="plate_X", timepoint=2.5` → `result["sample_uid"] == "plate_X"`, `result["timepoint"] == 2.5`.
-- [ ] 6.16 Add `test_compute_tracked_tip_traits_no_csv_defaults_sample_uid_to_series_name` — no CSV → `result["sample_uid"] == result["series"]`, `np.isnan(result["timepoint"])`.
-- [ ] 6.17 Add `test_track_id_values_match_inst_track_name` — synthetic .slp with custom track names `["alpha", "beta"]` → `set(row["track_id"] for row in result["tracks"]) == {"alpha", "beta"}`.
-- [ ] 6.18 Run `uv run pytest tests/test_tracked_tip_pipeline.py -x` — all FAIL with `ImportError`.
+- [x] 6.1 Create `tests/test_tracked_tip_pipeline.py`. Add a synthetic-`.slp`-builder helper or import from conftest.
+- [x] 6.2 Add `test_compute_tracked_tip_traits_returns_expected_dict_keys` — synthetic 5-frame .slp with 2 tracks → result dict has top-level keys `{schema_version, pipeline, units, series, sample_uid, timepoint, tracks, trajectories}`.
+- [x] 6.3 Add `test_compute_tracked_tip_traits_schema_version_is_1` — `result["schema_version"] == 1`.
+- [x] 6.4 Add `test_compute_tracked_tip_traits_units_dict` — `result["units"] == {"lengths": "pixels", "ratios": "dimensionless", "counts": "dimensionless", "time": "unspecified"}`.
+- [x] 6.5 Add `test_compute_tracked_tip_traits_tracks_table_one_row_per_track_id` — synthetic 2-track .slp → `len(result["tracks"]) == 2`. Each row has keys `{track_id, n_frames_tracked, n_frames_total, tracking_coverage, tip_trajectory_length, tip_displacement_net}`.
+- [x] 6.6 Add `test_compute_tracked_tip_traits_trajectories_table_one_row_per_track_frame` — synthetic 5-frame × 2-track .slp where every instance is tracked → `len(result["trajectories"]) == 10`.
+- [x] 6.7 Add `test_tip_trajectory_length_straight_line` — synthetic .slp where one track moves in a straight line of known length (e.g. (0,0) → (3,0) → (6,0) → (10,0)) → `tip_trajectory_length == 10.0`.
+- [x] 6.8 Add `test_tip_displacement_net_straight_line` — same straight-line track → `tip_displacement_net == 10.0`.
+- [x] 6.9 Add `test_tip_displacement_net_round_trip_returns_to_origin` — track (0,0) → (5,0) → (0,0) → `tip_displacement_net == 0.0`, `tip_trajectory_length == 10.0`. **Validates the geometric distinction.**
+- [x] 6.10 Add `test_tip_displacement_net_right_angle_path` — track (0,0) → (3,0) → (3,4) → `tip_trajectory_length == 7.0`, `tip_displacement_net == 5.0` (3-4-5 triangle).
+- [x] 6.11 Add `test_tracking_coverage_full` — every frame tracked → `tracking_coverage == 1.0`.
+- [x] 6.12 Add `test_tracking_coverage_partial` — track present in 3 of 5 frames → `tracking_coverage == 0.6`.
+- [x] 6.13 Add `test_compute_tracked_tip_traits_single_frame_track_zero_displacement_nan_length` — track present in 1 frame only → `tip_displacement_net == 0.0`, `np.isnan(tip_trajectory_length)`, `n_frames_tracked == 1`. **Codifies the documented asymmetry.**
+- [x] 6.14 Add `test_compute_tracked_tip_traits_zero_tracks` — synthetic .slp with NO tracked instances anywhere → `len(result["tracks"]) == 0`, `len(result["trajectories"]) == 0`, no crash.
+- [x] 6.15 Add `test_compute_tracked_tip_traits_emits_sample_uid_and_timepoint_from_csv` — `Series.load(primary_path=..., csv_path=metadata_csv, sample_uid="plate_X")` where the CSV has a row with `plant_qr_code="plate_X", timepoint=2.5` → `result["sample_uid"] == "plate_X"`, `result["timepoint"] == 2.5`.
+- [x] 6.16 Add `test_compute_tracked_tip_traits_no_csv_defaults_sample_uid_to_series_name` — no CSV → `result["sample_uid"] == result["series"]`, `np.isnan(result["timepoint"])`.
+- [x] 6.17 Add `test_track_id_values_match_inst_track_name` — synthetic .slp with custom track names `["alpha", "beta"]` → `set(row["track_id"] for row in result["tracks"]) == {"alpha", "beta"}`.
+- [x] 6.18 Run `uv run pytest tests/test_tracked_tip_pipeline.py -x` — all FAIL with `ImportError`.
 
 ## 7. Implement `TrackedTipPipeline` class (TDD green phase 3)
 
-- [ ] 7.1 Create `sleap_roots/tracked_tip_pipeline.py`. Imports: `from sleap_roots.trait_pipelines import Pipeline, TraitDef, _json_sanitize, NumpyArrayEncoder`; `from sleap_roots.lengths import get_root_lengths`; `from sleap_roots.bases import get_base_tip_dist`.
-- [ ] 7.2 Define `_TRACKED_TIP_UNITS = {"lengths": "pixels", "ratios": "dimensionless", "counts": "dimensionless", "time": "unspecified"}`.
-- [ ] 7.3 Define class `TrackedTipPipeline(Pipeline)` with `traits` list per the design doc DAG-A topology:
+- [x] 7.1 Create `sleap_roots/tracked_tip_pipeline.py`. Imports: `from sleap_roots.trait_pipelines import Pipeline, TraitDef, _json_sanitize, NumpyArrayEncoder`; `from sleap_roots.lengths import get_root_lengths`; `from sleap_roots.bases import get_base_tip_dist`.
+- [x] 7.2 Define `_TRACKED_TIP_UNITS = {"lengths": "pixels", "ratios": "dimensionless", "counts": "dimensionless", "time": "unspecified"}`.
+- [x] 7.3 Define class `TrackedTipPipeline(Pipeline)` with `traits` list per the design doc DAG-A topology:
   - `track_xy` (input)
   - `n_frames_tracked`, `n_frames_total` (inputs)
   - `track_first_xy = lambda xy: xy[0]` (`input_traits=["track_xy"]`)
@@ -115,7 +115,7 @@ These tests exercise the pipeline class without writing files — pure compute m
   - `tip_displacement_net = get_base_tip_dist` (`input_traits=["track_first_xy", "track_last_xy"]`)
   - `tip_trajectory_length = get_root_lengths` (`input_traits=["track_xy"]`)
   - `tracking_coverage = lambda nt, ntot: nt / ntot if ntot else np.nan` (`input_traits=["n_frames_tracked", "n_frames_total"]`)
-- [ ] 7.4 Implement `compute_tracked_tip_traits(self, series, *, write_csv=False, write_json=False, output_dir=".", emit_trajectories=True, csv_summary_suffix=".tracked_tip_traits.csv", csv_trajectory_suffix=".tracked_tip_trajectories.csv", json_suffix=".tracked_tip_traits.json")`. Algorithm:
+- [x] 7.4 Implement `compute_tracked_tip_traits(self, series, *, write_csv=False, write_json=False, output_dir=".", emit_trajectories=True, csv_summary_suffix=".tracked_tip_traits.csv", csv_trajectory_suffix=".tracked_tip_trajectories.csv", json_suffix=".tracked_tip_traits.json")`. Algorithm:
   1. Validate via `validate_series_for_tracked_tip(series)` — raises early on bad inputs.
   2. Get `df = series.get_tracked_tips()` (already frame-sorted).
   3. Build `n_frames_total = len(series)`.
@@ -127,73 +127,73 @@ These tests exercise the pipeline class without writing files — pure compute m
      - Append per-track summary row to `result["tracks"]`.
   6. If `emit_trajectories`: append every `(track_id, frame, tip_x, tip_y)` row to `result["trajectories"]` (already in frame-sorted order from the groupby).
   7. Write outputs per `write_csv` / `write_json` flags.
-- [ ] 7.5 Implement `_build_tracked_tip_dataframes(result, emit_trajectories) -> Tuple[pd.DataFrame, Optional[pd.DataFrame]]` — returns (summary_df, trajectory_df) for CSV write. Trajectory df is `None` when `emit_trajectories=False`.
-- [ ] 7.6 Add Google-style docstrings to class + every method.
-- [ ] 7.7 Re-export `TrackedTipPipeline` from `sleap_roots/__init__.py`.
-- [ ] 7.8 Run `uv run pytest tests/test_tracked_tip_pipeline.py -v` — all tests from §6 pass.
-- [ ] 7.9 Run `uv run pytest tests/ -x` — full suite green.
+- [x] 7.5 Implement `_build_tracked_tip_dataframes(result, emit_trajectories) -> Tuple[pd.DataFrame, Optional[pd.DataFrame]]` — returns (summary_df, trajectory_df) for CSV write. Trajectory df is `None` when `emit_trajectories=False`.
+- [x] 7.6 Add Google-style docstrings to class + every method.
+- [x] 7.7 Re-export `TrackedTipPipeline` from `sleap_roots/__init__.py`.
+- [x] 7.8 Run `uv run pytest tests/test_tracked_tip_pipeline.py -v` — all tests from §6 pass.
+- [x] 7.9 Run `uv run pytest tests/ -x` — full suite green.
 
 ## 8. Write failing tests for CSV/JSON file emission (TDD red phase 4)
 
-- [ ] 8.1 Add `test_compute_tracked_tip_traits_writes_summary_csv` — `compute_tracked_tip_traits(series, write_csv=True, output_dir=tmp_path)` → `<series>.tracked_tip_traits.csv` exists, parsed columns are `["series", "sample_uid", "timepoint", "track_id", "n_frames_tracked", "n_frames_total", "tracking_coverage", "tip_trajectory_length", "tip_displacement_net"]`.
-- [ ] 8.2 Add `test_compute_tracked_tip_traits_writes_trajectory_csv` — same call → `<series>.tracked_tip_trajectories.csv` exists, parsed columns are `["series", "sample_uid", "timepoint", "track_id", "frame", "tip_x", "tip_y"]`.
-- [ ] 8.3 Add `test_compute_tracked_tip_traits_writes_json_with_both_tables` — `write_json=True` → `<series>.tracked_tip_traits.json` exists, parses to a dict with `tracks` and `trajectories` arrays at top level (NOT nested under another key).
-- [ ] 8.4 Add `test_compute_tracked_tip_traits_emit_trajectories_false_skips_trajectory_csv` — `emit_trajectories=False, write_csv=True` → summary CSV exists but trajectory CSV does NOT exist (`tmp_path` doesn't contain it).
-- [ ] 8.5 Add `test_compute_tracked_tip_traits_emit_trajectories_false_omits_trajectories_in_json` — same kwargs with `write_json=True` → JSON's top-level dict has `tracks` array but `trajectories` array is empty `[]` (or omitted; design choice — pick one and codify).
-- [ ] 8.6 Add `test_compute_tracked_tip_traits_csv_repeats_series_sample_uid_timepoint_per_row` — CSV has `series`, `sample_uid`, `timepoint` value on EVERY row (CSV/JSON asymmetry).
-- [ ] 8.7 Add `test_compute_tracked_tip_traits_json_top_level_scalars_not_in_per_row` — JSON's `tracks[i]` and `trajectories[i]` rows do NOT contain `series`, `sample_uid`, `timepoint` keys (those are top-level).
-- [ ] 8.8 Add `test_compute_tracked_tip_traits_json_nan_to_null` — synthetic single-frame track → JSON's `tracks[0]["tip_trajectory_length"]` is `null` (verifies `_json_sanitize` is wired).
-- [ ] 8.9 Run `uv run pytest tests/test_tracked_tip_pipeline.py -k write -x` — all FAIL.
+- [x] 8.1 Add `test_compute_tracked_tip_traits_writes_summary_csv` — `compute_tracked_tip_traits(series, write_csv=True, output_dir=tmp_path)` → `<series>.tracked_tip_traits.csv` exists, parsed columns are `["series", "sample_uid", "timepoint", "track_id", "n_frames_tracked", "n_frames_total", "tracking_coverage", "tip_trajectory_length", "tip_displacement_net"]`.
+- [x] 8.2 Add `test_compute_tracked_tip_traits_writes_trajectory_csv` — same call → `<series>.tracked_tip_trajectories.csv` exists, parsed columns are `["series", "sample_uid", "timepoint", "track_id", "frame", "tip_x", "tip_y"]`.
+- [x] 8.3 Add `test_compute_tracked_tip_traits_writes_json_with_both_tables` — `write_json=True` → `<series>.tracked_tip_traits.json` exists, parses to a dict with `tracks` and `trajectories` arrays at top level (NOT nested under another key).
+- [x] 8.4 Add `test_compute_tracked_tip_traits_emit_trajectories_false_skips_trajectory_csv` — `emit_trajectories=False, write_csv=True` → summary CSV exists but trajectory CSV does NOT exist (`tmp_path` doesn't contain it).
+- [x] 8.5 Add `test_compute_tracked_tip_traits_emit_trajectories_false_omits_trajectories_in_json` — same kwargs with `write_json=True` → JSON's top-level dict has `tracks` array but `trajectories` array is empty `[]` (or omitted; design choice — pick one and codify).
+- [x] 8.6 Add `test_compute_tracked_tip_traits_csv_repeats_series_sample_uid_timepoint_per_row` — CSV has `series`, `sample_uid`, `timepoint` value on EVERY row (CSV/JSON asymmetry).
+- [x] 8.7 Add `test_compute_tracked_tip_traits_json_top_level_scalars_not_in_per_row` — JSON's `tracks[i]` and `trajectories[i]` rows do NOT contain `series`, `sample_uid`, `timepoint` keys (those are top-level).
+- [x] 8.8 Add `test_compute_tracked_tip_traits_json_nan_to_null` — synthetic single-frame track → JSON's `tracks[0]["tip_trajectory_length"]` is `null` (verifies `_json_sanitize` is wired).
+- [x] 8.9 Run `uv run pytest tests/test_tracked_tip_pipeline.py -k write -x` — all FAIL.
 
 ## 9. Implement file emission (TDD green phase 4)
 
-- [ ] 9.1 Implement `_build_tracked_tip_dataframes` (see §7.5). Repeat top-level `series` / `sample_uid` / `timepoint` on every row in both DataFrames.
-- [ ] 9.2 Wire `write_csv` / `write_json` / `emit_trajectories` in `compute_tracked_tip_traits`. JSON sanitize via `_json_sanitize(result)` from `trait_pipelines.py`.
-- [ ] 9.3 Decide: `emit_trajectories=False` makes JSON's `trajectories` an empty list `[]` (consistent with `tracks` being empty for zero-tracks case) — codify in spec scenario from §8.5.
-- [ ] 9.4 Run `uv run pytest tests/test_tracked_tip_pipeline.py -k write -v` — all 8 pass.
-- [ ] 9.5 Run `uv run pytest tests/ -x` — full suite green.
+- [x] 9.1 Implement `_build_tracked_tip_dataframes` (see §7.5). Repeat top-level `series` / `sample_uid` / `timepoint` on every row in both DataFrames.
+- [x] 9.2 Wire `write_csv` / `write_json` / `emit_trajectories` in `compute_tracked_tip_traits`. JSON sanitize via `_json_sanitize(result)` from `trait_pipelines.py`.
+- [x] 9.3 Decide: `emit_trajectories=False` makes JSON's `trajectories` an empty list `[]` (consistent with `tracks` being empty for zero-tracks case) — codify in spec scenario from §8.5.
+- [x] 9.4 Run `uv run pytest tests/test_tracked_tip_pipeline.py -k write -v` — all 8 pass.
+- [x] 9.5 Run `uv run pytest tests/ -x` — full suite green.
 
 ## 10. Write failing tests for batch method (TDD red phase 5)
 
-- [ ] 10.1 Add `test_compute_batch_tracked_tip_traits_concatenates_summary` — 3 synthetic Series with 2 tracks each → batch summary CSV has 6 rows (2 × 3).
-- [ ] 10.2 Add `test_compute_batch_tracked_tip_traits_concatenates_trajectories` — 3 synthetic Series → batch trajectory CSV has Σ(per-series tracked instances) rows.
-- [ ] 10.3 Add `test_compute_batch_tracked_tip_traits_writes_json_list` — batch JSON parses to a `list` of per-series dicts (length 3), each shaped like `compute_tracked_tip_traits` output.
-- [ ] 10.4 Add `test_compute_batch_tracked_tip_traits_emit_trajectories_false` — batch with `emit_trajectories=False` → batch trajectory CSV does NOT exist; summary CSV does.
-- [ ] 10.5 Add `test_compute_batch_tracked_tip_traits_empty_input` — `compute_batch_tracked_tip_traits([])` → empty DataFrame, empty JSON list, no crash.
-- [ ] 10.6 Run `uv run pytest tests/test_tracked_tip_pipeline.py -k batch -x` — all 5 FAIL.
+- [x] 10.1 Add `test_compute_batch_tracked_tip_traits_concatenates_summary` — 3 synthetic Series with 2 tracks each → batch summary CSV has 6 rows (2 × 3).
+- [x] 10.2 Add `test_compute_batch_tracked_tip_traits_concatenates_trajectories` — 3 synthetic Series → batch trajectory CSV has Σ(per-series tracked instances) rows.
+- [x] 10.3 Add `test_compute_batch_tracked_tip_traits_writes_json_list` — batch JSON parses to a `list` of per-series dicts (length 3), each shaped like `compute_tracked_tip_traits` output.
+- [x] 10.4 Add `test_compute_batch_tracked_tip_traits_emit_trajectories_false` — batch with `emit_trajectories=False` → batch trajectory CSV does NOT exist; summary CSV does.
+- [x] 10.5 Add `test_compute_batch_tracked_tip_traits_empty_input` — `compute_batch_tracked_tip_traits([])` → empty DataFrame, empty JSON list, no crash.
+- [x] 10.6 Run `uv run pytest tests/test_tracked_tip_pipeline.py -k batch -x` — all 5 FAIL.
 
 ## 11. Implement batch method (TDD green phase 5)
 
-- [ ] 11.1 Implement `compute_batch_tracked_tip_traits(self, all_series, *, write_csv=False, write_json=False, output_dir=".", csv_summary_name="tracked_tip_batch_traits.csv", csv_trajectory_name="tracked_tip_batch_trajectories.csv", json_name="tracked_tip_batch_traits.json", emit_trajectories=True)`. Mirrors `compute_batch_plate_traits` at [trait_pipelines.py:3327](sleap_roots/trait_pipelines.py#L3327): walks all series, calls per-series method, collects per-series result dicts into a list, concatenates per-series summary DataFrames into one, ditto trajectory DataFrames.
-- [ ] 11.2 Run `uv run pytest tests/test_tracked_tip_pipeline.py -k batch -v` — all 5 pass.
-- [ ] 11.3 Run `uv run pytest tests/ -x` — full suite green.
+- [x] 11.1 Implement `compute_batch_tracked_tip_traits(self, all_series, *, write_csv=False, write_json=False, output_dir=".", csv_summary_name="tracked_tip_batch_traits.csv", csv_trajectory_name="tracked_tip_batch_trajectories.csv", json_name="tracked_tip_batch_traits.json", emit_trajectories=True)`. Mirrors `compute_batch_plate_traits` at [trait_pipelines.py:3327](sleap_roots/trait_pipelines.py#L3327): walks all series, calls per-series method, collects per-series result dicts into a list, concatenates per-series summary DataFrames into one, ditto trajectory DataFrames.
+- [x] 11.2 Run `uv run pytest tests/test_tracked_tip_pipeline.py -k batch -v` — all 5 pass.
+- [x] 11.3 Run `uv run pytest tests/ -x` — full suite green.
 
 ## 12. Real-fixture integration tests (TDD red + green merged — fixture already committed in §1)
 
 These tests use the real `tests/data/circumnutation_plate/` fixture. No new implementation needed at this point; if they fail, the failure is in the pipeline or the fixture (fix appropriately).
 
-- [ ] 12.1 Add `test_real_fixture_with_csv_metadata` — `Series.load(primary_path="tests/data/circumnutation_plate/plate_001_greyscale.tracked.slp", csv_path="tests/data/circumnutation_plate/fixture_metadata.csv", sample_uid="plate_001")` → `TrackedTipPipeline().compute_tracked_tip_traits(series)`. Assertions:
+- [x] 12.1 Add `test_real_fixture_with_csv_metadata` — `Series.load(primary_path="tests/data/circumnutation_plate/plate_001_greyscale.tracked.slp", csv_path="tests/data/circumnutation_plate/fixture_metadata.csv", sample_uid="plate_001")` → `TrackedTipPipeline().compute_tracked_tip_traits(series)`. Assertions:
   - `result["sample_uid"] == "plate_001"`.
   - `result["timepoint"] == 0.0`.
   - `len(result["tracks"]) == 6`.
   - Every track has `0 <= tracking_coverage <= 1`.
   - `len(result["trajectories"]) == 1866` (311 frames × 6 tracked instances per frame, verified during brainstorm).
   - All output column names present (no missing).
-- [ ] 12.2 Add `test_real_fixture_no_csv_metadata` — `Series.load(primary_path=..., series_name="plate_001")` (NO `csv_path`). Same pipeline call. Assertions:
+- [x] 12.2 Add `test_real_fixture_no_csv_metadata` — `Series.load(primary_path=..., series_name="plate_001")` (NO `csv_path`). Same pipeline call. Assertions:
   - `result["sample_uid"] == "plate_001"` (defaults from `series_name` per Workstream 1).
   - `np.isnan(result["timepoint"])`.
   - `len(result["tracks"]) == 6`, `len(result["trajectories"]) == 1866`.
   - Every numeric trait value matches its corresponding row in `test_real_fixture_with_csv_metadata` (only the metadata changes, not the geometry).
-- [ ] 12.3 Add `test_real_fixture_track_id_values` — assert `set(row["track_id"] for row in result["tracks"]) == {"track_0", "track_1", "track_2", "track_3", "track_4", "track_5"}` (verified during brainstorm).
-- [ ] 12.4 Add `test_real_fixture_track_order_non_determinism_handled` — explicit assert on the brainstorm-verified observation: walk frames 0 and 1 of the real .slp directly via sleap-io, confirm positional order differs across the two frames, then assert that the pipeline output is correctly grouped by `track_id`. **Regression test for the per-instance iteration requirement.**
-- [ ] 12.5 Run `uv run pytest tests/test_tracked_tip_pipeline.py::test_real_fixture -v` — all 4 pass on Linux + Windows + macOS in CI.
-- [ ] 12.6 Run `uv run pytest tests/ -x` — full suite green.
+- [x] 12.3 Add `test_real_fixture_track_id_values` — assert `set(row["track_id"] for row in result["tracks"]) == {"track_0", "track_1", "track_2", "track_3", "track_4", "track_5"}` (verified during brainstorm).
+- [x] 12.4 Add `test_real_fixture_track_order_non_determinism_handled` — explicit assert on the brainstorm-verified observation: walk frames 0 and 1 of the real .slp directly via sleap-io, confirm positional order differs across the two frames, then assert that the pipeline output is correctly grouped by `track_id`. **Regression test for the per-instance iteration requirement.**
+- [x] 12.5 Run `uv run pytest tests/test_tracked_tip_pipeline.py::test_real_fixture -v` — all 4 pass on Linux + Windows + macOS in CI.
+- [x] 12.6 Run `uv run pytest tests/ -x` — full suite green.
 
 ## 13. Lint, format, docstrings
 
-- [ ] 13.1 `uv run black sleap_roots tests` — format all touched files.
-- [ ] 13.2 `uv run pydocstyle --convention=google sleap_roots/tracked_tip_pipeline.py sleap_roots/series.py` — Google docstrings on every public function / method / class.
-- [ ] 13.3 Verify imports are sorted (Black handles this; pydocstyle confirms).
+- [x] 13.1 `uv run black sleap_roots tests` — format all touched files.
+- [x] 13.2 `uv run pydocstyle --convention=google sleap_roots/tracked_tip_pipeline.py sleap_roots/series.py` — Google docstrings on every public function / method / class.
+- [x] 13.3 Verify imports are sorted (Black handles this; pydocstyle confirms).
 - [ ] 13.4 Run `uv run pytest tests/ --cov=sleap_roots --cov-report=term-missing` — coverage maintained or increased; new files have ≥90% coverage.
 
 ## 14. Documentation
@@ -207,8 +207,8 @@ These tests use the real `tests/data/circumnutation_plate/` fixture. No new impl
 
 ## 15. OpenSpec validation + final checks
 
-- [ ] 15.1 Run `openspec validate add-tracked-tip-pipeline --strict` — clean (no errors).
-- [ ] 15.2 Run `openspec show add-tracked-tip-pipeline --json --deltas-only > /tmp/deltas.json` — verify the deltas describe ADDED requirements only (no MODIFIED or REMOVED).
+- [x] 15.1 Run `openspec validate add-tracked-tip-pipeline --strict` — clean (no errors).
+- [x] 15.2 Run `openspec show add-tracked-tip-pipeline --json --deltas-only > /tmp/deltas.json` — verify the deltas describe ADDED requirements only (no MODIFIED or REMOVED).
 - [ ] 15.3 `git diff --stat` — verify the size matches the proposal's `Affected code` estimate (no surprise files modified).
 
 ## 16. PR + review

--- a/openspec/changes/add-tracked-tip-pipeline/tasks.md
+++ b/openspec/changes/add-tracked-tip-pipeline/tasks.md
@@ -1,0 +1,226 @@
+# Tasks: Add `TrackedTipPipeline` (Workstream 2 of 2026-04-23 design, issue #129)
+
+**Source of truth for architecture**: `docs/superpowers/specs/2026-04-23-timelapse-diff-and-tip-kinematics-design.md` § Workstream 2.
+
+**Workflow guarantees**:
+
+- Strict TDD: each subsection writes failing tests BEFORE implementation. Test-helper additions (e.g. extending the synthetic-`.slp` builder) land atomically with the tests that need them.
+- All commands use `uv run` (`uv run pytest`, `uv run black`, `uv run pydocstyle`).
+- No implementation merged until every follow-up issue (#186 / #187 / #188 / #189) is linked in the PR body.
+- Substrate scope is FROZEN — no velocity / curvature / circumnutation traits in this PR. They live in separate downstream pipeline classes (filed as future work).
+
+## 1. Pre-flight: copy real fixture into `tests/data/` (Git LFS)
+
+This lands FIRST because the integration tests in §11 depend on it. No Python code yet — just commit the fixture files so `git lfs ls-files` shows them tracked.
+
+- [ ] 1.1 Verify Git LFS hooks installed: `git lfs ls-files | head -3` shows existing `.slp` / `.h5` files in `tests/data/`. If not, install with `git lfs install`.
+- [ ] 1.2 Confirm `*.slp` is already tracked by LFS: `git check-attr -a tests/data/multiple_arabidopsis_11do/6039_1.primary.predictions.slp` shows `filter: lfs`. If not, fix `.gitattributes` first.
+- [ ] 1.3 Create `tests/data/circumnutation_plate/` directory.
+- [ ] 1.4 Copy `Z:\users\eberrigan\circumnutation\20250819_Suyash_Patil_CMTN_Kitx_vs_Hk1-3_07-30-25\run_20250827_091833\plate_001_greyscale.tracked.slp` → `tests/data/circumnutation_plate/plate_001_greyscale.tracked.slp` (184 KB).
+- [ ] 1.5 Synthesize `tests/data/circumnutation_plate/fixture_metadata.csv` with one row:
+  ```
+  plant_qr_code,genotype,treatment,number_of_plants_cylinder,timepoint
+  plate_001,KitaakeX,MOCK,6,0
+  ```
+- [ ] 1.6 Write `tests/data/circumnutation_plate/README.md` per the standard template (issue #168). Required sections:
+  - Purpose (input fixture for `TrackedTipPipeline` integration tests)
+  - Imaging geometry (plate, 6 plants, ~5h imaging at ~10-min intervals — derived from filename datetime stamps)
+  - Acquisition context (Suyash Patil, KitaakeX vs hk1-3, MOCK treatment, 2025-07-30)
+  - Contents (the .slp file, the synthesized CSV — explicit list)
+  - Conversion provenance (which source file mapped to which fixture file; what columns were renamed/dropped)
+  - Known limitations (per-frame CSV NOT shipped — deferred to #186; column-name caveat — `plant_qr_code` value `"plate_001"` is a plate identifier, NOT a plant identifier, legacy convention; #163 will rename)
+  - Related issues (#129, #163, #168, #186, #187, #188)
+- [ ] 1.7 `git add tests/data/circumnutation_plate/` and verify `git status` shows the .slp as `LFS`. Commit: `git commit -m "tests: add circumnutation_plate fixture for TrackedTipPipeline (#129)"`. DO NOT push until the PR is opened.
+
+## 2. Write failing tests for `Series.get_tracked_tips` (TDD red phase 1)
+
+These tests come FIRST — `get_tracked_tips` is the substrate accessor on which the pipeline + every downstream consumer depends.
+
+- [ ] 2.1 Locate or extend a synthetic-`.slp`-builder helper in `tests/conftest.py` or `tests/test_series.py` that constructs a tracked `.slp` via `sio.save_slp(...)` with `sio.Track` objects attached to instances via `inst.track = sio.Track(name="track_N")`. **Critical**: this helper accepts `n_frames`, `n_tracks`, `track_positions` (per-frame, per-track xy), `skeleton_node_names` (default `["r0"]` for single-node, configurable for multi-node), and `instance_order` (per-frame list of track names — supports the regression test for non-deterministic positional ordering across frames).
+- [ ] 2.2 Add `test_get_tracked_tips_returns_long_dataframe` — synthetic 3-frame .slp with 2 tracks → DataFrame with columns `["track_id", "frame", "tip_x", "tip_y"]`, 6 rows total.
+- [ ] 2.3 Add `test_get_tracked_tips_sorted_by_track_then_frame` — synthetic 3-frame .slp where instance positional order is RANDOMIZED per frame (frame 0: `[track_a, track_b]`; frame 1: `[track_b, track_a]`) → output DataFrame's `(track_id, frame)` column is monotonically sorted within each track group. **This is the regression test for the brainstorm-verified track-order non-determinism.**
+- [ ] 2.4 Add `test_get_tracked_tips_auto_detects_root_type_from_populated_path` — `Series.load(primary_path=...)` (lateral/crown empty) → `series.get_tracked_tips()` (no kwarg) succeeds and reads from primary.
+- [ ] 2.5 Add `test_get_tracked_tips_raises_when_multiple_paths_populated_no_root_type` — `Series.load(primary_path=..., lateral_path=...)` → `series.get_tracked_tips()` raises `ValueError` mentioning `root_type`.
+- [ ] 2.6 Add `test_get_tracked_tips_raises_when_zero_paths_populated` — `Series.load()` (none populated) → `ValueError` mentioning `root_type` and the missing path kwargs.
+- [ ] 2.7 Add `test_get_tracked_tips_raises_on_untracked_instance` — synthetic .slp where one instance has `inst.track = None` → `ValueError` mentioning the offending frame index AND `sleap.ai/tracking`.
+- [ ] 2.8 Add `test_get_tracked_tips_raises_on_empty_track_name` — synthetic .slp where `inst.track = sio.Track(name="")` → same `ValueError` as 2.7 (empty-name treated as untracked).
+- [ ] 2.9 Add `test_get_tracked_tips_single_node_skeleton` — synthetic .slp with skeleton `['r0']` (one node) → output `tip_x`, `tip_y` are the node's coordinates (`pts[-1]` is `pts[0]`).
+- [ ] 2.10 Add `test_get_tracked_tips_multi_node_skeleton` — synthetic .slp with skeleton `['base', 'mid', 'tip']` → output `tip_x`, `tip_y` are the LAST node's coordinates (the convention).
+- [ ] 2.11 Run `uv run pytest tests/test_series.py -k get_tracked_tips -x` — all 9 FAIL with `AttributeError: 'Series' object has no attribute 'get_tracked_tips'`.
+
+## 3. Implement `Series.get_tracked_tips` (TDD green phase 1)
+
+- [ ] 3.1 Add `get_tracked_tips(self, root_type: Optional[Literal["primary", "lateral", "crown"]] = None) -> pd.DataFrame` method to `Series` class in `sleap_roots/series.py`. Implementation:
+  - Resolve `root_type` (auto-detect when `None`); raise `ValueError` on zero / >1 populated paths.
+  - Get the labels object for the resolved root type (`self.primary_labels` / `self.lateral_labels` / `self.crown_labels`).
+  - Iterate `for frame_idx in range(len(labels)):` then `for inst in labels[frame_idx].instances:`. Note: existing accessors use `lf.user_instances + lf.unused_predictions` — confirm whether this matches what we want for tracked predictions (see open question in §3.4).
+  - For each instance: assert `inst.track is not None and inst.track.name`; raise `ValueError` listing offending frame index + `sleap.ai/tracking` URL otherwise.
+  - Append row dict `{"track_id": inst.track.name, "frame": frame_idx, "tip_x": inst.numpy()[-1, 0], "tip_y": inst.numpy()[-1, 1]}`.
+  - Return `pd.DataFrame(rows).sort_values(["track_id", "frame"]).reset_index(drop=True)`.
+- [ ] 3.2 Update `Series` class docstring to mention `get_tracked_tips`. Add Google-style docstring to the new method covering Args / Returns / Raises.
+- [ ] 3.3 Verify via `uv run pytest tests/test_series.py -k get_tracked_tips -v` — all 9 pass.
+- [ ] 3.4 **Open question for code review**: which instance set to iterate — `lf.instances` (all), `lf.predicted_instances`, or `lf.user_instances + lf.unused_predictions` (existing convention)? Verify on the real fixture: `uv run --no-project python -c "import sleap_io as sio; lbls = sio.load_slp(r'tests/data/circumnutation_plate/plate_001_greyscale.tracked.slp'); print(len(lbls.labeled_frames[0].instances), len(lbls.labeled_frames[0].predicted_instances), len(lbls.labeled_frames[0].user_instances))"`. Document the choice in the docstring.
+- [ ] 3.5 Run `uv run pytest tests/ -x` — full suite green (no regressions on existing accessors).
+
+## 4. Write failing tests for `validate_tracked_slp` + `validate_series_for_tracked_tip` (TDD red phase 2)
+
+- [ ] 4.1 Add `test_validate_tracked_slp_passes_on_fully_tracked` — synthetic .slp where every instance has `inst.track is not None` → `validate_tracked_slp(path)` returns `None`, no raise.
+- [ ] 4.2 Add `test_validate_tracked_slp_raises_on_untracked_instance` — synthetic .slp with one untracked instance → `ValueError` listing the offending frame index AND `sleap.ai/tracking`.
+- [ ] 4.3 Add `test_validate_tracked_slp_lists_all_offending_frames` — synthetic .slp with 3 untracked instances across 3 different frames → error message lists all 3 frame indices.
+- [ ] 4.4 Add `test_validate_series_for_tracked_tip_resolves_root_type` — `Series.load(primary_path=tracked_slp)` → `validate_series_for_tracked_tip(series)` (no `root_type`) succeeds.
+- [ ] 4.5 Add `test_validate_series_for_tracked_tip_explicit_root_type` — `Series.load(primary_path=tracked_slp, lateral_path=other_tracked)` → `validate_series_for_tracked_tip(series, root_type="primary")` succeeds; `root_type="lateral"` validates the other path.
+- [ ] 4.6 Add `test_validate_series_for_tracked_tip_raises_on_zero_or_multiple_paths_no_root_type` — same pattern as `get_tracked_tips` errors.
+- [ ] 4.7 Run `uv run pytest tests/test_series.py -k validate -x` — all 6 FAIL with `ImportError` (functions don't exist yet).
+
+## 5. Implement `validate_tracked_slp` + `validate_series_for_tracked_tip` (TDD green phase 2)
+
+- [ ] 5.1 Add `validate_tracked_slp(slp_path: Union[str, Path]) -> None` as a module-level function in `sleap_roots/series.py` (NOT a method on `Series` — it operates on a path string before any `Series` is constructed). Implementation: open via `sio.load_slp`, walk frames + instances, collect frames with any untracked instance, raise `ValueError` if any.
+- [ ] 5.2 Add `validate_series_for_tracked_tip(series: Series, root_type: Optional[str] = None) -> None` as a module-level function. Implementation: resolve root_type, check the relevant `<root_type>_path` attribute is set, assert skeleton has ≥1 node, call `validate_tracked_slp` on the resolved path.
+- [ ] 5.3 Re-export both from `sleap_roots/__init__.py`.
+- [ ] 5.4 Run `uv run pytest tests/test_series.py -k validate -v` — all 6 pass.
+- [ ] 5.5 Run `uv run pytest tests/ -x` — full suite green.
+
+## 6. Write failing tests for `TrackedTipPipeline` DAG composition (TDD red phase 3)
+
+These tests exercise the pipeline class without writing files — pure compute method, in-memory result dict.
+
+- [ ] 6.1 Create `tests/test_tracked_tip_pipeline.py`. Add a synthetic-`.slp`-builder helper or import from conftest.
+- [ ] 6.2 Add `test_compute_tracked_tip_traits_returns_expected_dict_keys` — synthetic 5-frame .slp with 2 tracks → result dict has top-level keys `{schema_version, pipeline, units, series, sample_uid, timepoint, tracks, trajectories}`.
+- [ ] 6.3 Add `test_compute_tracked_tip_traits_schema_version_is_1` — `result["schema_version"] == 1`.
+- [ ] 6.4 Add `test_compute_tracked_tip_traits_units_dict` — `result["units"] == {"lengths": "pixels", "ratios": "dimensionless", "counts": "dimensionless", "time": "unspecified"}`.
+- [ ] 6.5 Add `test_compute_tracked_tip_traits_tracks_table_one_row_per_track_id` — synthetic 2-track .slp → `len(result["tracks"]) == 2`. Each row has keys `{track_id, n_frames_tracked, n_frames_total, tracking_coverage, tip_trajectory_length, tip_displacement_net}`.
+- [ ] 6.6 Add `test_compute_tracked_tip_traits_trajectories_table_one_row_per_track_frame` — synthetic 5-frame × 2-track .slp where every instance is tracked → `len(result["trajectories"]) == 10`.
+- [ ] 6.7 Add `test_tip_trajectory_length_straight_line` — synthetic .slp where one track moves in a straight line of known length (e.g. (0,0) → (3,0) → (6,0) → (10,0)) → `tip_trajectory_length == 10.0`.
+- [ ] 6.8 Add `test_tip_displacement_net_straight_line` — same straight-line track → `tip_displacement_net == 10.0`.
+- [ ] 6.9 Add `test_tip_displacement_net_round_trip_returns_to_origin` — track (0,0) → (5,0) → (0,0) → `tip_displacement_net == 0.0`, `tip_trajectory_length == 10.0`. **Validates the geometric distinction.**
+- [ ] 6.10 Add `test_tip_displacement_net_right_angle_path` — track (0,0) → (3,0) → (3,4) → `tip_trajectory_length == 7.0`, `tip_displacement_net == 5.0` (3-4-5 triangle).
+- [ ] 6.11 Add `test_tracking_coverage_full` — every frame tracked → `tracking_coverage == 1.0`.
+- [ ] 6.12 Add `test_tracking_coverage_partial` — track present in 3 of 5 frames → `tracking_coverage == 0.6`.
+- [ ] 6.13 Add `test_compute_tracked_tip_traits_single_frame_track_zero_displacement_nan_length` — track present in 1 frame only → `tip_displacement_net == 0.0`, `np.isnan(tip_trajectory_length)`, `n_frames_tracked == 1`. **Codifies the documented asymmetry.**
+- [ ] 6.14 Add `test_compute_tracked_tip_traits_zero_tracks` — synthetic .slp with NO tracked instances anywhere → `len(result["tracks"]) == 0`, `len(result["trajectories"]) == 0`, no crash.
+- [ ] 6.15 Add `test_compute_tracked_tip_traits_emits_sample_uid_and_timepoint_from_csv` — `Series.load(primary_path=..., csv_path=metadata_csv, sample_uid="plate_X")` where the CSV has a row with `plant_qr_code="plate_X", timepoint=2.5` → `result["sample_uid"] == "plate_X"`, `result["timepoint"] == 2.5`.
+- [ ] 6.16 Add `test_compute_tracked_tip_traits_no_csv_defaults_sample_uid_to_series_name` — no CSV → `result["sample_uid"] == result["series"]`, `np.isnan(result["timepoint"])`.
+- [ ] 6.17 Add `test_track_id_values_match_inst_track_name` — synthetic .slp with custom track names `["alpha", "beta"]` → `set(row["track_id"] for row in result["tracks"]) == {"alpha", "beta"}`.
+- [ ] 6.18 Run `uv run pytest tests/test_tracked_tip_pipeline.py -x` — all FAIL with `ImportError`.
+
+## 7. Implement `TrackedTipPipeline` class (TDD green phase 3)
+
+- [ ] 7.1 Create `sleap_roots/tracked_tip_pipeline.py`. Imports: `from sleap_roots.trait_pipelines import Pipeline, TraitDef, _json_sanitize, NumpyArrayEncoder`; `from sleap_roots.lengths import get_root_lengths`; `from sleap_roots.bases import get_base_tip_dist`.
+- [ ] 7.2 Define `_TRACKED_TIP_UNITS = {"lengths": "pixels", "ratios": "dimensionless", "counts": "dimensionless", "time": "unspecified"}`.
+- [ ] 7.3 Define class `TrackedTipPipeline(Pipeline)` with `traits` list per the design doc DAG-A topology:
+  - `track_xy` (input)
+  - `n_frames_tracked`, `n_frames_total` (inputs)
+  - `track_first_xy = lambda xy: xy[0]` (`input_traits=["track_xy"]`)
+  - `track_last_xy = lambda xy: xy[-1]` (`input_traits=["track_xy"]`)
+  - `tip_displacement_net = get_base_tip_dist` (`input_traits=["track_first_xy", "track_last_xy"]`)
+  - `tip_trajectory_length = get_root_lengths` (`input_traits=["track_xy"]`)
+  - `tracking_coverage = lambda nt, ntot: nt / ntot if ntot else np.nan` (`input_traits=["n_frames_tracked", "n_frames_total"]`)
+- [ ] 7.4 Implement `compute_tracked_tip_traits(self, series, *, write_csv=False, write_json=False, output_dir=".", emit_trajectories=True, csv_summary_suffix=".tracked_tip_traits.csv", csv_trajectory_suffix=".tracked_tip_trajectories.csv", json_suffix=".tracked_tip_traits.json")`. Algorithm:
+  1. Validate via `validate_series_for_tracked_tip(series)` — raises early on bad inputs.
+  2. Get `df = series.get_tracked_tips()` (already frame-sorted).
+  3. Build `n_frames_total = len(series)`.
+  4. Build `result` dict skeleton with top-level scalars (`schema_version=1`, `pipeline="TrackedTipPipeline"`, `units=_TRACKED_TIP_UNITS`, `series=series.series_name`, `sample_uid=series.sample_uid`, `timepoint=series.timepoint`, `tracks=[]`, `trajectories=[]`).
+  5. For each `track_id, group in df.groupby("track_id")`:
+     - `track_xy = group[["tip_x", "tip_y"]].values` (frame-sorted because the DataFrame is sorted).
+     - `n_frames_tracked = len(group)`.
+     - Run the TraitDef DAG with these inputs.
+     - Append per-track summary row to `result["tracks"]`.
+  6. If `emit_trajectories`: append every `(track_id, frame, tip_x, tip_y)` row to `result["trajectories"]` (already in frame-sorted order from the groupby).
+  7. Write outputs per `write_csv` / `write_json` flags.
+- [ ] 7.5 Implement `_build_tracked_tip_dataframes(result, emit_trajectories) -> Tuple[pd.DataFrame, Optional[pd.DataFrame]]` — returns (summary_df, trajectory_df) for CSV write. Trajectory df is `None` when `emit_trajectories=False`.
+- [ ] 7.6 Add Google-style docstrings to class + every method.
+- [ ] 7.7 Re-export `TrackedTipPipeline` from `sleap_roots/__init__.py`.
+- [ ] 7.8 Run `uv run pytest tests/test_tracked_tip_pipeline.py -v` — all tests from §6 pass.
+- [ ] 7.9 Run `uv run pytest tests/ -x` — full suite green.
+
+## 8. Write failing tests for CSV/JSON file emission (TDD red phase 4)
+
+- [ ] 8.1 Add `test_compute_tracked_tip_traits_writes_summary_csv` — `compute_tracked_tip_traits(series, write_csv=True, output_dir=tmp_path)` → `<series>.tracked_tip_traits.csv` exists, parsed columns are `["series", "sample_uid", "timepoint", "track_id", "n_frames_tracked", "n_frames_total", "tracking_coverage", "tip_trajectory_length", "tip_displacement_net"]`.
+- [ ] 8.2 Add `test_compute_tracked_tip_traits_writes_trajectory_csv` — same call → `<series>.tracked_tip_trajectories.csv` exists, parsed columns are `["series", "sample_uid", "timepoint", "track_id", "frame", "tip_x", "tip_y"]`.
+- [ ] 8.3 Add `test_compute_tracked_tip_traits_writes_json_with_both_tables` — `write_json=True` → `<series>.tracked_tip_traits.json` exists, parses to a dict with `tracks` and `trajectories` arrays at top level (NOT nested under another key).
+- [ ] 8.4 Add `test_compute_tracked_tip_traits_emit_trajectories_false_skips_trajectory_csv` — `emit_trajectories=False, write_csv=True` → summary CSV exists but trajectory CSV does NOT exist (`tmp_path` doesn't contain it).
+- [ ] 8.5 Add `test_compute_tracked_tip_traits_emit_trajectories_false_omits_trajectories_in_json` — same kwargs with `write_json=True` → JSON's top-level dict has `tracks` array but `trajectories` array is empty `[]` (or omitted; design choice — pick one and codify).
+- [ ] 8.6 Add `test_compute_tracked_tip_traits_csv_repeats_series_sample_uid_timepoint_per_row` — CSV has `series`, `sample_uid`, `timepoint` value on EVERY row (CSV/JSON asymmetry).
+- [ ] 8.7 Add `test_compute_tracked_tip_traits_json_top_level_scalars_not_in_per_row` — JSON's `tracks[i]` and `trajectories[i]` rows do NOT contain `series`, `sample_uid`, `timepoint` keys (those are top-level).
+- [ ] 8.8 Add `test_compute_tracked_tip_traits_json_nan_to_null` — synthetic single-frame track → JSON's `tracks[0]["tip_trajectory_length"]` is `null` (verifies `_json_sanitize` is wired).
+- [ ] 8.9 Run `uv run pytest tests/test_tracked_tip_pipeline.py -k write -x` — all FAIL.
+
+## 9. Implement file emission (TDD green phase 4)
+
+- [ ] 9.1 Implement `_build_tracked_tip_dataframes` (see §7.5). Repeat top-level `series` / `sample_uid` / `timepoint` on every row in both DataFrames.
+- [ ] 9.2 Wire `write_csv` / `write_json` / `emit_trajectories` in `compute_tracked_tip_traits`. JSON sanitize via `_json_sanitize(result)` from `trait_pipelines.py`.
+- [ ] 9.3 Decide: `emit_trajectories=False` makes JSON's `trajectories` an empty list `[]` (consistent with `tracks` being empty for zero-tracks case) — codify in spec scenario from §8.5.
+- [ ] 9.4 Run `uv run pytest tests/test_tracked_tip_pipeline.py -k write -v` — all 8 pass.
+- [ ] 9.5 Run `uv run pytest tests/ -x` — full suite green.
+
+## 10. Write failing tests for batch method (TDD red phase 5)
+
+- [ ] 10.1 Add `test_compute_batch_tracked_tip_traits_concatenates_summary` — 3 synthetic Series with 2 tracks each → batch summary CSV has 6 rows (2 × 3).
+- [ ] 10.2 Add `test_compute_batch_tracked_tip_traits_concatenates_trajectories` — 3 synthetic Series → batch trajectory CSV has Σ(per-series tracked instances) rows.
+- [ ] 10.3 Add `test_compute_batch_tracked_tip_traits_writes_json_list` — batch JSON parses to a `list` of per-series dicts (length 3), each shaped like `compute_tracked_tip_traits` output.
+- [ ] 10.4 Add `test_compute_batch_tracked_tip_traits_emit_trajectories_false` — batch with `emit_trajectories=False` → batch trajectory CSV does NOT exist; summary CSV does.
+- [ ] 10.5 Add `test_compute_batch_tracked_tip_traits_empty_input` — `compute_batch_tracked_tip_traits([])` → empty DataFrame, empty JSON list, no crash.
+- [ ] 10.6 Run `uv run pytest tests/test_tracked_tip_pipeline.py -k batch -x` — all 5 FAIL.
+
+## 11. Implement batch method (TDD green phase 5)
+
+- [ ] 11.1 Implement `compute_batch_tracked_tip_traits(self, all_series, *, write_csv=False, write_json=False, output_dir=".", csv_summary_name="tracked_tip_batch_traits.csv", csv_trajectory_name="tracked_tip_batch_trajectories.csv", json_name="tracked_tip_batch_traits.json", emit_trajectories=True)`. Mirrors `compute_batch_plate_traits` at [trait_pipelines.py:3327](sleap_roots/trait_pipelines.py#L3327): walks all series, calls per-series method, collects per-series result dicts into a list, concatenates per-series summary DataFrames into one, ditto trajectory DataFrames.
+- [ ] 11.2 Run `uv run pytest tests/test_tracked_tip_pipeline.py -k batch -v` — all 5 pass.
+- [ ] 11.3 Run `uv run pytest tests/ -x` — full suite green.
+
+## 12. Real-fixture integration tests (TDD red + green merged — fixture already committed in §1)
+
+These tests use the real `tests/data/circumnutation_plate/` fixture. No new implementation needed at this point; if they fail, the failure is in the pipeline or the fixture (fix appropriately).
+
+- [ ] 12.1 Add `test_real_fixture_with_csv_metadata` — `Series.load(primary_path="tests/data/circumnutation_plate/plate_001_greyscale.tracked.slp", csv_path="tests/data/circumnutation_plate/fixture_metadata.csv", sample_uid="plate_001")` → `TrackedTipPipeline().compute_tracked_tip_traits(series)`. Assertions:
+  - `result["sample_uid"] == "plate_001"`.
+  - `result["timepoint"] == 0.0`.
+  - `len(result["tracks"]) == 6`.
+  - Every track has `0 <= tracking_coverage <= 1`.
+  - `len(result["trajectories"]) == 1866` (311 frames × 6 tracked instances per frame, verified during brainstorm).
+  - All output column names present (no missing).
+- [ ] 12.2 Add `test_real_fixture_no_csv_metadata` — `Series.load(primary_path=..., series_name="plate_001")` (NO `csv_path`). Same pipeline call. Assertions:
+  - `result["sample_uid"] == "plate_001"` (defaults from `series_name` per Workstream 1).
+  - `np.isnan(result["timepoint"])`.
+  - `len(result["tracks"]) == 6`, `len(result["trajectories"]) == 1866`.
+  - Every numeric trait value matches its corresponding row in `test_real_fixture_with_csv_metadata` (only the metadata changes, not the geometry).
+- [ ] 12.3 Add `test_real_fixture_track_id_values` — assert `set(row["track_id"] for row in result["tracks"]) == {"track_0", "track_1", "track_2", "track_3", "track_4", "track_5"}` (verified during brainstorm).
+- [ ] 12.4 Add `test_real_fixture_track_order_non_determinism_handled` — explicit assert on the brainstorm-verified observation: walk frames 0 and 1 of the real .slp directly via sleap-io, confirm positional order differs across the two frames, then assert that the pipeline output is correctly grouped by `track_id`. **Regression test for the per-instance iteration requirement.**
+- [ ] 12.5 Run `uv run pytest tests/test_tracked_tip_pipeline.py::test_real_fixture -v` — all 4 pass on Linux + Windows + macOS in CI.
+- [ ] 12.6 Run `uv run pytest tests/ -x` — full suite green.
+
+## 13. Lint, format, docstrings
+
+- [ ] 13.1 `uv run black sleap_roots tests` — format all touched files.
+- [ ] 13.2 `uv run pydocstyle --convention=google sleap_roots/tracked_tip_pipeline.py sleap_roots/series.py` — Google docstrings on every public function / method / class.
+- [ ] 13.3 Verify imports are sorted (Black handles this; pydocstyle confirms).
+- [ ] 13.4 Run `uv run pytest tests/ --cov=sleap_roots --cov-report=term-missing` — coverage maintained or increased; new files have ≥90% coverage.
+
+## 14. Documentation
+
+- [ ] 14.1 Add a tutorial section to `docs/` (existing `docs/tutorials/` directory) showing end-to-end usage:
+  - Load a tracked .slp via `Series.load`.
+  - Call `TrackedTipPipeline().compute_tracked_tip_traits(series, write_csv=True, write_json=True)`.
+  - Inspect the output CSVs and JSON.
+  - Note: this is the substrate; downstream pipelines (circumnutation, etc.) consume this output.
+- [ ] 14.2 Add CHANGELOG entry under `Added`: pipeline, accessor, validators. Under `Fixed`: nothing (additive change). Under `Internal`: started per-pipeline-module pattern (#189 tracks the rest).
+
+## 15. OpenSpec validation + final checks
+
+- [ ] 15.1 Run `openspec validate add-tracked-tip-pipeline --strict` — clean (no errors).
+- [ ] 15.2 Run `openspec show add-tracked-tip-pipeline --json --deltas-only > /tmp/deltas.json` — verify the deltas describe ADDED requirements only (no MODIFIED or REMOVED).
+- [ ] 15.3 `git diff --stat` — verify the size matches the proposal's `Affected code` estimate (no surprise files modified).
+
+## 16. PR + review
+
+- [ ] 16.1 Open PR against `main`. Title: `feat: TrackedTipPipeline for tracked-tip kinematic substrate (Workstream 2 of #129) (#129)`.
+- [ ] 16.2 PR body links: #129 (closes), #170 (unblocks plate-intra-series and tracked-tip cases), #186 (deferred), #187 (deferred), #188 (deferred), #189 (per-pipeline-module pattern starts here).
+- [ ] 16.3 Run `/review-pr` (Phase 3.5 self-review) before requesting human review.
+- [ ] 16.4 Run `/pre-merge` after review approvals.
+- [ ] 16.5 Verify CI green on Linux + Windows + macOS, Python 3.11.
+- [ ] 16.6 Address any review feedback. New comments → new failing test → green test → push.
+
+## 17. Post-merge: archive the OpenSpec change
+
+- [ ] 17.1 After merge, run `openspec archive add-tracked-tip-pipeline` — moves the change folder under `openspec/changes/archive/YYYY-MM-DD-add-tracked-tip-pipeline/` and creates the `openspec/specs/tracked-tip-pipeline/spec.md`.
+- [ ] 17.2 Commit and push the archive: `docs: archive add-tracked-tip-pipeline after PR #N merge`.

--- a/openspec/changes/add-tracked-tip-pipeline/tasks.md
+++ b/openspec/changes/add-tracked-tip-pipeline/tasks.md
@@ -198,12 +198,9 @@ These tests use the real `tests/data/circumnutation_plate/` fixture. No new impl
 
 ## 14. Documentation
 
-- [ ] 14.1 Add a tutorial section to `docs/` (existing `docs/tutorials/` directory) showing end-to-end usage:
-  - Load a tracked .slp via `Series.load`.
-  - Call `TrackedTipPipeline().compute_tracked_tip_traits(series, write_csv=True, write_json=True)`.
-  - Inspect the output CSVs and JSON.
-  - Note: this is the substrate; downstream pipelines (circumnutation, etc.) consume this output.
-- [ ] 14.2 Add CHANGELOG entry under `Added`: pipeline, accessor, validators. Under `Fixed`: nothing (additive change). Under `Internal`: started per-pipeline-module pattern (#189 tracks the rest).
+- [ ] 14.1 Add a tutorial section to `docs/` (existing `docs/tutorials/` directory) showing end-to-end usage. _Deferred to a follow-up PR — existing tutorials are full Jupyter notebooks (notebooks/*.ipynb) which is heavier than this substrate-focused PR warrants. Docstrings + the mermaid graph below provide canonical reference._
+- [x] 14.2 Add CHANGELOG entry under `Added`: pipeline, accessor, validators. Under `Internal`: started per-pipeline-module pattern (#189 tracks the rest). _CHANGELOG is at `docs/changelog.md` (lowercase)._
+- [x] 14.3 Generate `notebooks/TrackedTipPipeline_Mermaid_Graph.md` — DAG visualization mirroring the existing `DicotPipeline_Mermaid_Graph.md` and friends. Built directly from `TrackedTipPipeline().traits` via the same idiom in `notebooks/Pipeline_mermaid_diagrams.ipynb`. 8 distinct trait nodes.
 
 ## 15. OpenSpec validation + final checks
 

--- a/openspec/changes/add-tracked-tip-pipeline/tasks.md
+++ b/openspec/changes/add-tracked-tip-pipeline/tasks.md
@@ -210,8 +210,8 @@ These tests use the real `tests/data/circumnutation_plate/` fixture. No new impl
 
 ## 16. PR + review
 
-- [ ] 16.1 Open PR against `main`. Title: `feat: TrackedTipPipeline for tracked-tip kinematic substrate (Workstream 2 of #129) (#129)`.
-- [ ] 16.2 PR body links: #129 (closes), #170 (unblocks plate-intra-series and tracked-tip cases), #186 (deferred), #187 (deferred), #188 (deferred), #189 (per-pipeline-module pattern starts here).
+- [x] 16.1 Open PR against `main`. PR #190: https://github.com/talmolab/sleap-roots/pull/190 — title: `feat: TrackedTipPipeline for tracked-tip kinematic substrate (#129)`.
+- [x] 16.2 PR body links: #129 (closes), #186 / #187 / #188 / #189 (deferred follow-ups).
 - [ ] 16.3 Run `/review-pr` (Phase 3.5 self-review) before requesting human review.
 - [ ] 16.4 Run `/pre-merge` after review approvals.
 - [ ] 16.5 Verify CI green on Linux + Windows + macOS, Python 3.11.

--- a/openspec/changes/add-tracked-tip-pipeline/tasks.md
+++ b/openspec/changes/add-tracked-tip-pipeline/tasks.md
@@ -217,6 +217,17 @@ These tests use the real `tests/data/circumnutation_plate/` fixture. No new impl
 - [ ] 16.5 Verify CI green on Linux + Windows + macOS, Python 3.11.
 - [ ] 16.6 Address any review feedback. New comments → new failing test → green test → push.
 
+## 16b. Post-review fix: bound `tracking_coverage` to `[0.0, 1.0]` (TDD red → green)
+
+Surfaced by the multi-agent review (`/review-pr` on PR #190): `tracking_coverage` could exceed `1.0` when the source `.slp` has duplicate `(track_id, frame)` rows (pathological tracker output — merged tracks). The integration test asserts `0 ≤ coverage ≤ 1` and the spec promises it; the contract was silently violated under that adversarial input.
+
+Fixed via strict TDD with separate test + impl commits to leave a visible audit trail.
+
+- [x] 16b.1 RED: write a failing test in `tests/test_tracked_tip_pipeline.py` that constructs a `.slp` with one frame containing 2 instances of the same `track_id="t"`, calls `compute_tracked_tip_traits`, and asserts `tracking_coverage == 1.0` AND `n_frames_tracked == 1`. Run the test before implementing — confirm it FAILS with `AssertionError: 2.0 != 1.0`.
+- [x] 16b.2 GREEN: in `sleap_roots/tracked_tip_pipeline.py`'s per-track groupby, change `n_frames_tracked = len(group)` to `n_frames_tracked = int(group["frame"].nunique())`. Run the test — confirm it passes.
+- [x] 16b.3 Run full test suite — no regressions.
+- [x] 16b.4 Run `openspec validate add-tracked-tip-pipeline --strict` — confirm the new requirement parses cleanly.
+
 ## 17. Post-merge: archive the OpenSpec change
 
 - [ ] 17.1 After merge, run `openspec archive add-tracked-tip-pipeline` — moves the change folder under `openspec/changes/archive/YYYY-MM-DD-add-tracked-tip-pipeline/` and creates the `openspec/specs/tracked-tip-pipeline/spec.md`.

--- a/openspec/changes/add-tracked-tip-pipeline/tasks.md
+++ b/openspec/changes/add-tracked-tip-pipeline/tasks.md
@@ -228,6 +228,21 @@ Fixed via strict TDD with separate test + impl commits to leave a visible audit 
 - [x] 16b.3 Run full test suite — no regressions.
 - [x] 16b.4 Run `openspec validate add-tracked-tip-pipeline --strict` — confirm the new requirement parses cleanly.
 
+## 16c. Post-review fix: TraitDef `fn` values SHALL be picklable (TDD red → green)
+
+Surfaced by the multi-agent review (`/review-pr` on PR #190): the original implementation used inline lambdas (`fn=lambda xy: xy[0]`, `fn=lambda xy: xy[-1]`) for the per-track slicing TraitDef nodes. Lambdas are not picklable by default, which would silently block any future `multiprocessing`-based parallelization of the trait DAG.
+
+Fixed via strict TDD with separate test + impl commits.
+
+- [x] 16c.1 RED: write a failing test in `tests/test_tracked_tip_pipeline.py` that:
+  - Constructs a `TrackedTipPipeline()` instance.
+  - Calls `pickle.dumps(pipeline.traits)` — confirms it raises `pickle.PicklingError` (or `AttributeError` on older Python versions) before the fix.
+  - After the fix, asserts the call succeeds and round-trips via `pickle.loads(...)` to a list of equal length with the same trait names.
+  - Also iterates per-trait and asserts `pickle.dumps(trait_def.fn)` succeeds for each.
+- [x] 16c.2 GREEN: in `sleap_roots/tracked_tip_pipeline.py`, replace the two inline lambdas with module-level functions `_get_first_xy(xy)` and `_get_last_xy(xy)`. Both are picklable by reference. Run the test — confirm it passes.
+- [x] 16c.3 Run full test suite — no regressions.
+- [x] 16c.4 Run `openspec validate add-tracked-tip-pipeline --strict` — confirm the new requirement parses cleanly.
+
 ## 17. Post-merge: archive the OpenSpec change
 
 - [ ] 17.1 After merge, run `openspec archive add-tracked-tip-pipeline` — moves the change folder under `openspec/changes/archive/YYYY-MM-DD-add-tracked-tip-pipeline/` and creates the `openspec/specs/tracked-tip-pipeline/spec.md`.

--- a/sleap_roots/__init__.py
+++ b/sleap_roots/__init__.py
@@ -34,7 +34,10 @@ from sleap_roots.series import (
     find_all_slp_paths,
     load_series_from_h5s,
     load_series_from_slps,
+    validate_series_for_tracked_tip,
+    validate_tracked_slp,
 )
+from sleap_roots.tracked_tip_pipeline import TrackedTipPipeline
 
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release version.

--- a/sleap_roots/series.py
+++ b/sleap_roots/series.py
@@ -556,28 +556,14 @@ class Series:
                 `inst.track is None` or empty `inst.track.name` — the
                 pipeline requires SLEAP-tracked predictions.
         """
-        # Resolve root_type — auto-detect when None.
+        # Resolve root_type via the shared helper (validates explicit
+        # values + auto-detects when None).
         path_attrs = {
             "primary": self.primary_path,
             "lateral": self.lateral_path,
             "crown": self.crown_path,
         }
-        if root_type is None:
-            populated = [k for k, v in path_attrs.items() if v is not None]
-            if len(populated) == 0:
-                raise ValueError(
-                    "Cannot auto-detect root_type: none of primary_path, "
-                    "lateral_path, or crown_path is populated. Pass an "
-                    "explicit root_type kwarg or set one of those paths on "
-                    "Series.load."
-                )
-            if len(populated) > 1:
-                raise ValueError(
-                    f"Cannot auto-detect root_type: multiple paths populated "
-                    f"({populated}). Pass an explicit root_type kwarg "
-                    f"(one of {list(path_attrs.keys())})."
-                )
-            root_type = populated[0]
+        root_type = _resolve_root_type(path_attrs, root_type)
         # Get the labels object for the resolved root type.
         labels_attr = f"{root_type}_labels"
         labels = getattr(self, labels_attr, None)
@@ -953,6 +939,58 @@ def plot_instances(
     return h_lines
 
 
+_VALID_ROOT_TYPES = ("primary", "lateral", "crown")
+
+
+def _resolve_root_type(
+    path_attrs: Dict[str, Optional[str]],
+    root_type: Optional[str],
+) -> str:
+    """Resolve `root_type` from a populated-path mapping.
+
+    Shared helper used by `Series.get_tracked_tips` and
+    `validate_series_for_tracked_tip` to keep root-type validation +
+    auto-detection consistent across both call sites.
+
+    Args:
+        path_attrs: Dict mapping root-type strings (`'primary'` / `'lateral'`
+            / `'crown'`) to either a path or `None`.
+        root_type: Either `None` (auto-detect from `path_attrs`) or one of
+            the valid root-type strings.
+
+    Returns:
+        The resolved root-type string (one of `'primary'`, `'lateral'`,
+        `'crown'`).
+
+    Raises:
+        ValueError: When `root_type` is not `None` but is not in
+            `{'primary', 'lateral', 'crown'}`; when `root_type` is `None`
+            and zero or more than one path is populated.
+    """
+    if root_type is not None:
+        if root_type not in _VALID_ROOT_TYPES:
+            raise ValueError(
+                f"Invalid root_type={root_type!r}; must be one of "
+                f"{list(_VALID_ROOT_TYPES)}."
+            )
+        return root_type
+
+    populated = [k for k, v in path_attrs.items() if v is not None]
+    if len(populated) == 0:
+        raise ValueError(
+            "Cannot auto-detect root_type: none of primary_path, "
+            "lateral_path, or crown_path is populated. Pass an explicit "
+            f"root_type kwarg (one of {list(_VALID_ROOT_TYPES)})."
+        )
+    if len(populated) > 1:
+        raise ValueError(
+            f"Cannot auto-detect root_type: multiple paths populated "
+            f"({populated}). Pass an explicit root_type kwarg "
+            f"(one of {list(_VALID_ROOT_TYPES)})."
+        )
+    return populated[0]
+
+
 def validate_tracked_slp(slp_path: Union[str, Path]) -> None:
     """Validate that every instance in a .slp file has a non-empty track.
 
@@ -1018,21 +1056,7 @@ def validate_series_for_tracked_tip(
         "lateral": series.lateral_path,
         "crown": series.crown_path,
     }
-    if root_type is None:
-        populated = [k for k, v in path_attrs.items() if v is not None]
-        if len(populated) == 0:
-            raise ValueError(
-                "Cannot auto-detect root_type: none of primary_path, "
-                "lateral_path, or crown_path is populated on the series. "
-                "Pass an explicit root_type kwarg."
-            )
-        if len(populated) > 1:
-            raise ValueError(
-                f"Cannot auto-detect root_type: multiple paths populated "
-                f"({populated}). Pass an explicit root_type kwarg "
-                f"(one of {list(path_attrs.keys())})."
-            )
-        root_type = populated[0]
+    root_type = _resolve_root_type(path_attrs, root_type)
 
     resolved_path = path_attrs[root_type]
     if resolved_path is None:

--- a/sleap_roots/series.py
+++ b/sleap_roots/series.py
@@ -543,11 +543,13 @@ class Series:
             with a clean range index. One row per `(track_id, frame)` where
             the track has an instance.
 
-            The tip coordinate is the LAST node of the skeleton
-            (`inst.numpy()[-1]`), matching the convention used by
-            `sleap_roots.tips.get_tips`. This works for both single-node
-            skeletons (e.g. `["r0"]`) and multi-node skeletons (e.g.
-            `["base", "mid", "tip"]`).
+            Coordinates `tip_x`, `tip_y` are in image pixels (origin
+            top-left, y increases downward), matching the SLEAP
+            convention. The tip coordinate is the LAST node of the
+            skeleton (`inst.numpy()[-1]`), matching the convention used
+            by `sleap_roots.tips.get_tips`. This works for both
+            single-node skeletons (e.g. `["r0"]`) and multi-node
+            skeletons (e.g. `["base", "mid", "tip"]`).
 
         Raises:
             ValueError: When `root_type` is `None` and zero or more than

--- a/sleap_roots/series.py
+++ b/sleap_roots/series.py
@@ -524,6 +524,105 @@ class Series:
             crown_pts = np.stack([inst.numpy() for inst in gt_instances_cr], axis=0)
         return crown_pts
 
+    def get_tracked_tips(
+        self,
+        root_type: Optional[str] = None,
+    ) -> pd.DataFrame:
+        """Return per-frame tracked-tip rows in long format.
+
+        Args:
+            root_type: One of ``"primary"``, ``"lateral"``, ``"crown"``. When
+                ``None`` (default), auto-detects from whichever single
+                ``<root_type>_path`` is populated. Raises ``ValueError`` when
+                zero or more than one path is populated and ``root_type`` is
+                ``None``.
+
+        Returns:
+            A ``pandas.DataFrame`` with columns ``["track_id", "frame",
+            "tip_x", "tip_y"]`` in that order, sorted by ``(track_id, frame)``
+            with a clean range index. One row per ``(track_id, frame)`` where
+            the track has an instance.
+
+            The tip coordinate is the LAST node of the skeleton
+            (``inst.numpy()[-1]``), matching the convention used by
+            ``sleap_roots.tips.get_tips``. This works for both single-node
+            skeletons (e.g. ``["r0"]``) and multi-node skeletons (e.g.
+            ``["base", "mid", "tip"]``).
+
+        Raises:
+            ValueError: When ``root_type`` is ``None`` and zero or more than
+                one of ``primary_path`` / ``lateral_path`` / ``crown_path``
+                is populated. Also raised when any instance has
+                ``inst.track is None`` or empty ``inst.track.name`` — the
+                pipeline requires SLEAP-tracked predictions.
+        """
+        # Resolve root_type — auto-detect when None.
+        path_attrs = {
+            "primary": self.primary_path,
+            "lateral": self.lateral_path,
+            "crown": self.crown_path,
+        }
+        if root_type is None:
+            populated = [k for k, v in path_attrs.items() if v is not None]
+            if len(populated) == 0:
+                raise ValueError(
+                    "Cannot auto-detect root_type: none of primary_path, "
+                    "lateral_path, or crown_path is populated. Pass an "
+                    "explicit root_type kwarg or set one of those paths on "
+                    "Series.load."
+                )
+            if len(populated) > 1:
+                raise ValueError(
+                    f"Cannot auto-detect root_type: multiple paths populated "
+                    f"({populated}). Pass an explicit root_type kwarg "
+                    f"(one of {list(path_attrs.keys())})."
+                )
+            root_type = populated[0]
+        # Get the labels object for the resolved root type.
+        labels_attr = f"{root_type}_labels"
+        labels = getattr(self, labels_attr, None)
+        if labels is None:
+            raise ValueError(
+                f"{labels_attr} is not available — was {root_type}_path set "
+                f"on Series.load?"
+            )
+
+        # Iterate per-instance — tracker output does NOT preserve positional
+        # ordering across frames (verified during the #129 brainstorm: frame 0
+        # may be [track_0, 1, 2, 3, 4, 5] but frame 1 may be
+        # [track_0, 3, 4, 2, 1, 5]). We must read inst.track.name per instance.
+        rows = []
+        offending_frames = []
+        for lf in labels.labeled_frames:
+            for inst in lf.instances:
+                track = inst.track
+                if track is None or not getattr(track, "name", None):
+                    offending_frames.append(lf.frame_idx)
+                    continue
+                pts = inst.numpy()
+                tip_xy = pts[-1]  # last node = tip by skeleton convention
+                rows.append(
+                    {
+                        "track_id": track.name,
+                        "frame": lf.frame_idx,
+                        "tip_x": float(tip_xy[0]),
+                        "tip_y": float(tip_xy[1]),
+                    }
+                )
+
+        if offending_frames:
+            unique_frames = sorted(set(offending_frames))
+            raise ValueError(
+                f"TrackedTipPipeline requires tracked .slp predictions; "
+                f"untracked instances found at frame indices {unique_frames}. "
+                f"See https://sleap.ai/tutorials/tracking.html for tracking "
+                f"setup."
+            )
+
+        df = pd.DataFrame(rows, columns=["track_id", "frame", "tip_x", "tip_y"])
+        df = df.sort_values(["track_id", "frame"]).reset_index(drop=True)
+        return df
+
 
 def find_all_h5_paths(data_folders: Union[str, List[str]]) -> List[str]:
     """Find all .h5 paths from a list of folders.
@@ -852,3 +951,104 @@ def plot_instances(
         h_lines.append(h_lines_i)
 
     return h_lines
+
+
+def validate_tracked_slp(slp_path: Union[str, Path]) -> None:
+    """Validate that every instance in a .slp file has a non-empty track.
+
+    Used as an input precondition for ``TrackedTipPipeline``.
+
+    Args:
+        slp_path: Path to the .slp file to validate.
+
+    Returns:
+        ``None`` when every instance has a non-empty ``inst.track.name``.
+
+    Raises:
+        ValueError: When any instance has ``inst.track is None`` or empty
+            ``inst.track.name``. The error message lists ALL offending frame
+            indices and points to the SLEAP tracking documentation.
+    """
+    labels = sio.load_slp(str(slp_path))
+    offending = []
+    for lf in labels.labeled_frames:
+        for inst in lf.instances:
+            track = inst.track
+            if track is None or not getattr(track, "name", None):
+                offending.append(lf.frame_idx)
+                break  # one offender per frame is enough to flag the frame
+    if offending:
+        unique_frames = sorted(set(offending))
+        raise ValueError(
+            f"TrackedTipPipeline requires tracked .slp predictions; "
+            f"untracked instances found at frame indices {unique_frames} in "
+            f"{slp_path}. See https://sleap.ai/tutorials/tracking.html for "
+            f"tracking setup."
+        )
+
+
+def validate_series_for_tracked_tip(
+    series: Series,
+    root_type: Optional[str] = None,
+) -> None:
+    """Validate a ``Series`` is loadable by ``TrackedTipPipeline``.
+
+    Composite check: resolves ``root_type`` (auto-detect when ``None``),
+    asserts the corresponding ``<root_type>_path`` is set and the loaded
+    skeleton has at least one node, then calls ``validate_tracked_slp`` on
+    the resolved path.
+
+    Args:
+        series: The ``Series`` to validate.
+        root_type: One of ``"primary"``, ``"lateral"``, ``"crown"``. When
+            ``None``, auto-detects from whichever single ``<root_type>_path``
+            is populated.
+
+    Returns:
+        ``None`` when the series is valid for tracked-tip processing.
+
+    Raises:
+        ValueError: When ``root_type`` is ``None`` and zero or more than one
+            of ``primary_path`` / ``lateral_path`` / ``crown_path`` is
+            populated; when the resolved path's skeleton has zero nodes;
+            or when ``validate_tracked_slp`` raises (propagated).
+    """
+    path_attrs = {
+        "primary": series.primary_path,
+        "lateral": series.lateral_path,
+        "crown": series.crown_path,
+    }
+    if root_type is None:
+        populated = [k for k, v in path_attrs.items() if v is not None]
+        if len(populated) == 0:
+            raise ValueError(
+                "Cannot auto-detect root_type: none of primary_path, "
+                "lateral_path, or crown_path is populated on the series. "
+                "Pass an explicit root_type kwarg."
+            )
+        if len(populated) > 1:
+            raise ValueError(
+                f"Cannot auto-detect root_type: multiple paths populated "
+                f"({populated}). Pass an explicit root_type kwarg "
+                f"(one of {list(path_attrs.keys())})."
+            )
+        root_type = populated[0]
+
+    resolved_path = path_attrs[root_type]
+    if resolved_path is None:
+        raise ValueError(
+            f"root_type={root_type!r} requested but {root_type}_path is None "
+            f"on the series."
+        )
+
+    labels_attr = f"{root_type}_labels"
+    labels = getattr(series, labels_attr, None)
+    if labels is not None:
+        # Skeleton sanity check (every Labels has a `skeletons` list).
+        sks = getattr(labels, "skeletons", None) or []
+        if sks and len(sks[0].nodes) == 0:
+            raise ValueError(
+                f"{root_type} skeleton has zero nodes — cannot extract tips."
+            )
+
+    validate_tracked_slp(resolved_path)

--- a/sleap_roots/series.py
+++ b/sleap_roots/series.py
@@ -531,29 +531,29 @@ class Series:
         """Return per-frame tracked-tip rows in long format.
 
         Args:
-            root_type: One of ``"primary"``, ``"lateral"``, ``"crown"``. When
-                ``None`` (default), auto-detects from whichever single
-                ``<root_type>_path`` is populated. Raises ``ValueError`` when
-                zero or more than one path is populated and ``root_type`` is
-                ``None``.
+            root_type: One of `"primary"`, `"lateral"`, `"crown"`. When
+                `None` (default), auto-detects from whichever single
+                `<root_type>_path` is populated. Raises `ValueError` when
+                zero or more than one path is populated and `root_type` is
+                `None`.
 
         Returns:
-            A ``pandas.DataFrame`` with columns ``["track_id", "frame",
-            "tip_x", "tip_y"]`` in that order, sorted by ``(track_id, frame)``
-            with a clean range index. One row per ``(track_id, frame)`` where
+            A `pandas.DataFrame` with columns `["track_id", "frame",
+            "tip_x", "tip_y"]` in that order, sorted by `(track_id, frame)`
+            with a clean range index. One row per `(track_id, frame)` where
             the track has an instance.
 
             The tip coordinate is the LAST node of the skeleton
-            (``inst.numpy()[-1]``), matching the convention used by
-            ``sleap_roots.tips.get_tips``. This works for both single-node
-            skeletons (e.g. ``["r0"]``) and multi-node skeletons (e.g.
-            ``["base", "mid", "tip"]``).
+            (`inst.numpy()[-1]`), matching the convention used by
+            `sleap_roots.tips.get_tips`. This works for both single-node
+            skeletons (e.g. `["r0"]`) and multi-node skeletons (e.g.
+            `["base", "mid", "tip"]`).
 
         Raises:
-            ValueError: When ``root_type`` is ``None`` and zero or more than
-                one of ``primary_path`` / ``lateral_path`` / ``crown_path``
+            ValueError: When `root_type` is `None` and zero or more than
+                one of `primary_path` / `lateral_path` / `crown_path`
                 is populated. Also raised when any instance has
-                ``inst.track is None`` or empty ``inst.track.name`` — the
+                `inst.track is None` or empty `inst.track.name` — the
                 pipeline requires SLEAP-tracked predictions.
         """
         # Resolve root_type — auto-detect when None.
@@ -956,17 +956,17 @@ def plot_instances(
 def validate_tracked_slp(slp_path: Union[str, Path]) -> None:
     """Validate that every instance in a .slp file has a non-empty track.
 
-    Used as an input precondition for ``TrackedTipPipeline``.
+    Used as an input precondition for `TrackedTipPipeline`.
 
     Args:
         slp_path: Path to the .slp file to validate.
 
     Returns:
-        ``None`` when every instance has a non-empty ``inst.track.name``.
+        `None` when every instance has a non-empty `inst.track.name`.
 
     Raises:
-        ValueError: When any instance has ``inst.track is None`` or empty
-            ``inst.track.name``. The error message lists ALL offending frame
+        ValueError: When any instance has `inst.track is None` or empty
+            `inst.track.name`. The error message lists ALL offending frame
             indices and points to the SLEAP tracking documentation.
     """
     labels = sio.load_slp(str(slp_path))
@@ -991,27 +991,27 @@ def validate_series_for_tracked_tip(
     series: Series,
     root_type: Optional[str] = None,
 ) -> None:
-    """Validate a ``Series`` is loadable by ``TrackedTipPipeline``.
+    """Validate a `Series` is loadable by `TrackedTipPipeline`.
 
-    Composite check: resolves ``root_type`` (auto-detect when ``None``),
-    asserts the corresponding ``<root_type>_path`` is set and the loaded
-    skeleton has at least one node, then calls ``validate_tracked_slp`` on
+    Composite check: resolves `root_type` (auto-detect when `None`),
+    asserts the corresponding `<root_type>_path` is set and the loaded
+    skeleton has at least one node, then calls `validate_tracked_slp` on
     the resolved path.
 
     Args:
-        series: The ``Series`` to validate.
-        root_type: One of ``"primary"``, ``"lateral"``, ``"crown"``. When
-            ``None``, auto-detects from whichever single ``<root_type>_path``
+        series: The `Series` to validate.
+        root_type: One of `"primary"`, `"lateral"`, `"crown"`. When
+            `None`, auto-detects from whichever single `<root_type>_path`
             is populated.
 
     Returns:
-        ``None`` when the series is valid for tracked-tip processing.
+        `None` when the series is valid for tracked-tip processing.
 
     Raises:
-        ValueError: When ``root_type`` is ``None`` and zero or more than one
-            of ``primary_path`` / ``lateral_path`` / ``crown_path`` is
+        ValueError: When `root_type` is `None` and zero or more than one
+            of `primary_path` / `lateral_path` / `crown_path` is
             populated; when the resolved path's skeleton has zero nodes;
-            or when ``validate_tracked_slp`` raises (propagated).
+            or when `validate_tracked_slp` raises (propagated).
     """
     path_attrs = {
         "primary": series.primary_path,

--- a/sleap_roots/tracked_tip_pipeline.py
+++ b/sleap_roots/tracked_tip_pipeline.py
@@ -1,0 +1,421 @@
+"""TrackedTipPipeline: per-track tip-trajectory substrate from tracked .slp predictions.
+
+Issue #129 (Workstream 2 of the 2026-04-23 timelapse design). Consumes
+SLEAP-tracked predictions and emits a minimum-viable substrate of per-track
+geometric scalars plus the raw trajectory rows. **Scope is frozen** —
+velocity / curvature / circumnutation traits NEVER belong here; they live in
+separate downstream pipeline classes that REUSE this pipeline's
+``Series.get_tracked_tips`` accessor and trajectory output as their input
+substrate.
+
+Lives in its own file (NOT appended to the 3763-line ``trait_pipelines.py``
+megafile) — starts the per-pipeline-module pattern; the existing megafile
+split is tracked in #189.
+
+See:
+- ``docs/superpowers/specs/2026-04-23-timelapse-diff-and-tip-kinematics-design.md``
+  § Workstream 2 — design rationale and brainstorm decisions.
+- ``openspec/changes/add-tracked-tip-pipeline/`` — formal contract.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import attrs
+import numpy as np
+import pandas as pd
+
+from sleap_roots.bases import get_base_tip_dist
+from sleap_roots.lengths import get_root_lengths
+from sleap_roots.series import Series, validate_series_for_tracked_tip
+from sleap_roots.trait_pipelines import (
+    NumpyArrayEncoder,
+    Pipeline,
+    TraitDef,
+    _json_sanitize,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+_TRACKED_TIP_UNITS: Dict[str, str] = {
+    "lengths": "pixels",
+    "ratios": "dimensionless",
+    "counts": "dimensionless",
+    "time": "unspecified",
+}
+
+_SCHEMA_VERSION = 1
+
+_SUMMARY_COLUMNS: List[str] = [
+    "series",
+    "sample_uid",
+    "timepoint",
+    "track_id",
+    "n_frames_tracked",
+    "n_frames_total",
+    "tracking_coverage",
+    "tip_trajectory_length",
+    "tip_displacement_net",
+]
+_TRAJECTORY_COLUMNS: List[str] = [
+    "series",
+    "sample_uid",
+    "timepoint",
+    "track_id",
+    "frame",
+    "tip_x",
+    "tip_y",
+]
+
+
+def _tracking_coverage_fn(n_tracked: int, n_total: int) -> float:
+    """Fraction of frames in which a track has an instance.
+
+    ``np.nan`` when ``n_total == 0`` (defensive — pipeline iteration handles
+    empty input upstream so this is rarely reached).
+    """
+    if n_total == 0:
+        return float("nan")
+    return float(n_tracked) / float(n_total)
+
+
+@attrs.define
+class TrackedTipPipeline(Pipeline):
+    """Pipeline emitting per-track tip-trajectory substrate from tracked .slp.
+
+    Reuses existing trait functions DIRECTLY via TraitDef DAG composition —
+    no wrapper module. ``tip_displacement_net`` delegates to
+    ``sleap_roots.bases.get_base_tip_dist``; ``tip_trajectory_length``
+    delegates to ``sleap_roots.lengths.get_root_lengths``. The DAG provides
+    per-track input slicing (``track_first_xy = xy[0]``,
+    ``track_last_xy = xy[-1]``) so existing functions plug in unchanged.
+
+    Iteration unit is **per-track** (not per-frame as in DicotPipeline et
+    al.). The pipeline calls ``series.get_tracked_tips()`` to obtain a
+    long-format DataFrame sorted by ``(track_id, frame)``, groups by
+    ``track_id``, and runs the DAG once per group with the per-track inputs.
+    """
+
+    def define_traits(self) -> List[TraitDef]:
+        """Return the per-track TraitDef DAG.
+
+        Inputs (pre-populated per track when ``compute_frame_traits`` is
+        called): ``track_xy`` (Nx2 frame-sorted), ``n_frames_tracked``,
+        ``n_frames_total``.
+        """
+        return [
+            # Per-track slicing — DAG provides endpoint extraction for the
+            # existing distance function below.
+            TraitDef(
+                name="track_first_xy",
+                fn=lambda xy: xy[0],
+                input_traits=["track_xy"],
+                scalar=False,
+                include_in_csv=False,
+                description="First frame's tip (x, y) for this track.",
+            ),
+            TraitDef(
+                name="track_last_xy",
+                fn=lambda xy: xy[-1],
+                input_traits=["track_xy"],
+                scalar=False,
+                include_in_csv=False,
+                description="Last frame's tip (x, y) for this track.",
+            ),
+            # Trait scalars — existing trait functions used directly via DAG
+            # composition.
+            TraitDef(
+                name="tip_displacement_net",
+                fn=get_base_tip_dist,  # ← from bases.py, no wrapper
+                input_traits=["track_first_xy", "track_last_xy"],
+                scalar=True,
+                include_in_csv=True,
+                description=(
+                    "Euclidean distance from first-tracked-frame tip to "
+                    "last-tracked-frame tip (pixels)."
+                ),
+            ),
+            TraitDef(
+                name="tip_trajectory_length",
+                fn=get_root_lengths,  # ← from lengths.py, no wrapper
+                input_traits=["track_xy"],
+                scalar=True,
+                include_in_csv=True,
+                description=(
+                    "Cumulative arclength of the tip trajectory across all "
+                    "tracked frames (pixels). NaN for single-frame tracks "
+                    "(codebase NaN-on-empty-segments convention)."
+                ),
+            ),
+            TraitDef(
+                name="tracking_coverage",
+                fn=_tracking_coverage_fn,
+                input_traits=["n_frames_tracked", "n_frames_total"],
+                scalar=True,
+                include_in_csv=True,
+                description=(
+                    "n_frames_tracked / n_frames_total (dimensionless ratio "
+                    "in [0, 1])."
+                ),
+            ),
+        ]
+
+    def compute_tracked_tip_traits(
+        self,
+        series: Series,
+        *,
+        write_csv: bool = False,
+        write_json: bool = False,
+        output_dir: str = ".",
+        emit_trajectories: bool = True,
+        csv_summary_suffix: str = ".tracked_tip_traits.csv",
+        csv_trajectory_suffix: str = ".tracked_tip_trajectories.csv",
+        json_suffix: str = ".tracked_tip_traits.json",
+    ) -> Dict[str, Any]:
+        """Compute per-track tip-trajectory traits for one Series.
+
+        Args:
+            series: ``Series`` whose tracked .slp will be processed.
+            write_csv: When True, write the summary CSV and (unless
+                ``emit_trajectories=False``) the trajectory CSV to
+                ``output_dir``.
+            write_json: When True, write the per-series JSON file.
+            output_dir: Directory to write outputs to. Created if absent.
+            emit_trajectories: When False, suppress writing the trajectory
+                CSV and emit ``trajectories=[]`` in the in-memory and JSON
+                outputs.
+            csv_summary_suffix: Filename suffix for the summary CSV.
+            csv_trajectory_suffix: Filename suffix for the trajectory CSV.
+            json_suffix: Filename suffix for the JSON.
+
+        Returns:
+            A dict with keys ``schema_version`` (1), ``pipeline``
+            (``"TrackedTipPipeline"``), ``units`` (structured dict),
+            ``series`` (str), ``sample_uid`` (str), ``timepoint`` (float or
+            NaN), ``tracks`` (list of per-track dicts), ``trajectories``
+            (list of per-frame dicts; empty when ``emit_trajectories=False``).
+        """
+        # Validate input early — raises ValueError on untracked instances or
+        # zero/multiple paths populated without root_type.
+        validate_series_for_tracked_tip(series)
+
+        # Long-format trajectory rows (sorted by (track_id, frame)).
+        df = series.get_tracked_tips()
+        n_frames_total = len(series)
+
+        result: Dict[str, Any] = {
+            "schema_version": _SCHEMA_VERSION,
+            "pipeline": "TrackedTipPipeline",
+            "units": dict(_TRACKED_TIP_UNITS),
+            "series": series.series_name,
+            "sample_uid": series.sample_uid,
+            "timepoint": series.timepoint,
+            "tracks": [],
+            "trajectories": [],
+        }
+
+        # Per-track DAG iteration. Empty df → no iterations, empty arrays.
+        for track_id, group in df.groupby("track_id"):
+            track_xy = group[["tip_x", "tip_y"]].to_numpy(dtype=float)
+            initial_traits = {
+                "track_xy": track_xy,
+                "n_frames_tracked": len(group),
+                "n_frames_total": n_frames_total,
+            }
+            computed = self.compute_frame_traits(initial_traits)
+            result["tracks"].append(
+                {
+                    "track_id": str(track_id),
+                    "n_frames_tracked": int(initial_traits["n_frames_tracked"]),
+                    "n_frames_total": int(n_frames_total),
+                    "tracking_coverage": float(computed["tracking_coverage"]),
+                    "tip_trajectory_length": float(computed["tip_trajectory_length"]),
+                    "tip_displacement_net": float(computed["tip_displacement_net"]),
+                }
+            )
+
+        if emit_trajectories:
+            for _, row in df.iterrows():
+                result["trajectories"].append(
+                    {
+                        "track_id": str(row["track_id"]),
+                        "frame": int(row["frame"]),
+                        "tip_x": float(row["tip_x"]),
+                        "tip_y": float(row["tip_y"]),
+                    }
+                )
+
+        if write_csv or write_json:
+            Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+        if write_csv:
+            summary_df, trajectory_df = self._build_dataframes(
+                result, emit_trajectories=emit_trajectories
+            )
+            summary_path = (
+                Path(output_dir) / f"{series.series_name}{csv_summary_suffix}"
+            )
+            summary_df.to_csv(summary_path.as_posix(), index=False)
+            if emit_trajectories and trajectory_df is not None:
+                trajectory_path = (
+                    Path(output_dir) / f"{series.series_name}{csv_trajectory_suffix}"
+                )
+                trajectory_df.to_csv(trajectory_path.as_posix(), index=False)
+
+        if write_json:
+            json_path = Path(output_dir) / f"{series.series_name}{json_suffix}"
+            sanitized = _json_sanitize(result)
+            with open(json_path.as_posix(), "w") as f:
+                json.dump(
+                    sanitized,
+                    f,
+                    cls=NumpyArrayEncoder,
+                    allow_nan=False,
+                    ensure_ascii=False,
+                    indent=4,
+                )
+
+        return result
+
+    def _build_dataframes(
+        self,
+        result: Dict[str, Any],
+        *,
+        emit_trajectories: bool,
+    ) -> Tuple[pd.DataFrame, Optional[pd.DataFrame]]:
+        """Build per-series summary + trajectory DataFrames for CSV emission.
+
+        Returns ``(summary_df, trajectory_df)``. ``trajectory_df`` is ``None``
+        when ``emit_trajectories`` is False.
+        """
+        # Repeat top-level scalars on every row of both DataFrames.
+        series_name = result["series"]
+        sample_uid = result["sample_uid"]
+        timepoint = result["timepoint"]
+
+        summary_rows = [
+            {
+                "series": series_name,
+                "sample_uid": sample_uid,
+                "timepoint": timepoint,
+                **row,
+            }
+            for row in result["tracks"]
+        ]
+        summary_df = pd.DataFrame(summary_rows, columns=_SUMMARY_COLUMNS)
+
+        if not emit_trajectories:
+            return summary_df, None
+
+        trajectory_rows = [
+            {
+                "series": series_name,
+                "sample_uid": sample_uid,
+                "timepoint": timepoint,
+                **row,
+            }
+            for row in result["trajectories"]
+        ]
+        trajectory_df = pd.DataFrame(trajectory_rows, columns=_TRAJECTORY_COLUMNS)
+        return summary_df, trajectory_df
+
+    def compute_batch_tracked_tip_traits(
+        self,
+        all_series: List[Series],
+        *,
+        write_csv: bool = False,
+        write_json: bool = False,
+        output_dir: str = ".",
+        csv_summary_name: str = "tracked_tip_batch_traits.csv",
+        csv_trajectory_name: str = "tracked_tip_batch_trajectories.csv",
+        json_name: str = "tracked_tip_batch_traits.json",
+        emit_trajectories: bool = True,
+    ) -> Tuple[pd.DataFrame, Optional[pd.DataFrame], List[Dict[str, Any]]]:
+        """Run ``compute_tracked_tip_traits`` across multiple Series; concatenate.
+
+        Mirrors the existing ``compute_batch_plate_traits`` pattern in
+        ``trait_pipelines.py``: walks ``all_series``, calls the per-series
+        method, concatenates per-series DataFrames into one, collects
+        per-series result dicts into a list.
+
+        Args:
+            all_series: Sequence of ``Series`` objects to process.
+            write_csv: When True, write batch summary CSV and (unless
+                ``emit_trajectories=False``) batch trajectory CSV.
+            write_json: When True, write a single JSON file containing a
+                list of per-series result dicts.
+            output_dir: Directory to write outputs to. Created if absent.
+            csv_summary_name: Filename for the batch summary CSV.
+            csv_trajectory_name: Filename for the batch trajectory CSV.
+            json_name: Filename for the batch JSON.
+            emit_trajectories: When False, suppress trajectory output across
+                all series.
+
+        Returns:
+            ``(batch_summary_df, batch_trajectory_df_or_None, per_series_results)``.
+            ``batch_trajectory_df_or_None`` is ``None`` when
+            ``emit_trajectories`` is False; otherwise a concatenated
+            DataFrame across all series.
+        """
+        per_series_results: List[Dict[str, Any]] = []
+        per_series_summary_dfs: List[pd.DataFrame] = []
+        per_series_trajectory_dfs: List[pd.DataFrame] = []
+        for series in all_series:
+            result = self.compute_tracked_tip_traits(
+                series, emit_trajectories=emit_trajectories
+            )
+            per_series_results.append(result)
+            summary_df, trajectory_df = self._build_dataframes(
+                result, emit_trajectories=emit_trajectories
+            )
+            per_series_summary_dfs.append(summary_df)
+            if emit_trajectories and trajectory_df is not None:
+                per_series_trajectory_dfs.append(trajectory_df)
+
+        if per_series_summary_dfs:
+            batch_summary_df = pd.concat(
+                per_series_summary_dfs, axis=0, ignore_index=True
+            )
+        else:
+            batch_summary_df = pd.DataFrame(columns=_SUMMARY_COLUMNS)
+
+        if emit_trajectories:
+            if per_series_trajectory_dfs:
+                batch_trajectory_df = pd.concat(
+                    per_series_trajectory_dfs, axis=0, ignore_index=True
+                )
+            else:
+                batch_trajectory_df = pd.DataFrame(columns=_TRAJECTORY_COLUMNS)
+        else:
+            batch_trajectory_df = None
+
+        if write_csv or write_json:
+            Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+        if write_csv:
+            batch_summary_df.to_csv(
+                (Path(output_dir) / csv_summary_name).as_posix(), index=False
+            )
+            if emit_trajectories and batch_trajectory_df is not None:
+                batch_trajectory_df.to_csv(
+                    (Path(output_dir) / csv_trajectory_name).as_posix(), index=False
+                )
+
+        if write_json:
+            json_path = Path(output_dir) / json_name
+            sanitized = _json_sanitize(per_series_results)
+            with open(json_path.as_posix(), "w") as f:
+                json.dump(
+                    sanitized,
+                    f,
+                    cls=NumpyArrayEncoder,
+                    allow_nan=False,
+                    ensure_ascii=False,
+                    indent=4,
+                )
+
+        return batch_summary_df, batch_trajectory_df, per_series_results

--- a/sleap_roots/tracked_tip_pipeline.py
+++ b/sleap_roots/tracked_tip_pipeline.py
@@ -240,6 +240,32 @@ class TrackedTipPipeline(Pipeline):
             `series` (str), `sample_uid` (str), `timepoint` (float or
             NaN), `tracks` (list of per-track dicts), `trajectories`
             (list of per-frame dicts; empty when `emit_trajectories=False`).
+
+        Notes:
+            Tip coordinates `tip_x`, `tip_y` are in **image pixels**
+            (origin top-left, y increases downward), matching the SLEAP
+            convention. All length scalars (`tip_trajectory_length`,
+            `tip_displacement_net`) are pixel distances.
+
+            Single-frame edge case: when a track is tracked in exactly
+            one frame, the per-track summary row has
+            `tip_displacement_net == 0.0` (xy[0] == xy[-1] is a natural
+            geometric result) but `tip_trajectory_length` is `NaN` (the
+            existing `lengths.get_root_lengths` function's NaN-on-empty-
+            segments convention applies — single-frame trajectories have
+            zero segments). This asymmetry is intentional; users who want
+            either behavior coerced apply `fillna(0.0)` post-hoc, or
+            filter on `n_frames_tracked > 1` to exclude single-frame
+            tracks entirely.
+
+            `tracking_coverage` is computed as `n_frames_tracked /
+            n_frames_total`, where `n_frames_tracked` is the number of
+            UNIQUE frame indices in which the track has an instance
+            (duplicates from buggy tracker output are deduplicated).
+            Interpreting `tracking_coverage` as a temporal-coverage
+            fraction (e.g. "the plant was visible 60 % of the imaging
+            window") implicitly assumes uniform inter-frame spacing, a
+            property of the source data not enforced by this code.
         """
         # Validate input early — raises ValueError on untracked instances or
         # zero/multiple paths populated without root_type.

--- a/sleap_roots/tracked_tip_pipeline.py
+++ b/sleap_roots/tracked_tip_pipeline.py
@@ -226,9 +226,16 @@ class TrackedTipPipeline(Pipeline):
         # Per-track DAG iteration. Empty df → no iterations, empty arrays.
         for track_id, group in df.groupby("track_id"):
             track_xy = group[["tip_x", "tip_y"]].to_numpy(dtype=float)
+            # n_frames_tracked is the count of UNIQUE frames in which the
+            # track has an instance — NOT len(group). Pathological tracker
+            # output (over-eager merging) can produce duplicate
+            # (track_id, frame) rows; counting instances would push
+            # tracking_coverage above 1.0 and break the [0, 1] contract.
+            # The trajectory CSV preserves duplicates for debugging; only
+            # the per-track summary deduplicates.
             initial_traits = {
                 "track_xy": track_xy,
-                "n_frames_tracked": len(group),
+                "n_frames_tracked": int(group["frame"].nunique()),
                 "n_frames_total": n_frames_total,
             }
             computed = self.compute_frame_traits(initial_traits)

--- a/sleap_roots/tracked_tip_pipeline.py
+++ b/sleap_roots/tracked_tip_pipeline.py
@@ -1,22 +1,4 @@
-"""TrackedTipPipeline: per-track tip-trajectory substrate from tracked .slp predictions.
-
-Issue #129 (Workstream 2 of the 2026-04-23 timelapse design). Consumes
-SLEAP-tracked predictions and emits a minimum-viable substrate of per-track
-geometric scalars plus the raw trajectory rows. **Scope is frozen** —
-velocity / curvature / circumnutation traits NEVER belong here; they live in
-separate downstream pipeline classes that REUSE this pipeline's
-``Series.get_tracked_tips`` accessor and trajectory output as their input
-substrate.
-
-Lives in its own file (NOT appended to the 3763-line ``trait_pipelines.py``
-megafile) — starts the per-pipeline-module pattern; the existing megafile
-split is tracked in #189.
-
-See:
-- ``docs/superpowers/specs/2026-04-23-timelapse-diff-and-tip-kinematics-design.md``
-  § Workstream 2 — design rationale and brainstorm decisions.
-- ``openspec/changes/add-tracked-tip-pipeline/`` — formal contract.
-"""
+"""TrackedTipPipeline for per-track tip-trajectory analysis (issue #129)."""
 
 import json
 import logging
@@ -73,10 +55,16 @@ _TRAJECTORY_COLUMNS: List[str] = [
 
 
 def _tracking_coverage_fn(n_tracked: int, n_total: int) -> float:
-    """Fraction of frames in which a track has an instance.
+    """Compute the fraction of frames in which a track has an instance.
 
-    ``np.nan`` when ``n_total == 0`` (defensive — pipeline iteration handles
-    empty input upstream so this is rarely reached).
+    Args:
+        n_tracked: Number of frames in which the track has an instance.
+        n_total: Total number of frames in the series.
+
+    Returns:
+        `n_tracked / n_total` as a float in `[0, 1]`. Returns `np.nan` when
+        `n_total == 0` (defensive — pipeline iteration handles empty input
+        upstream so this branch is rarely reached).
     """
     if n_total == 0:
         return float("nan")
@@ -87,25 +75,42 @@ def _tracking_coverage_fn(n_tracked: int, n_total: int) -> float:
 class TrackedTipPipeline(Pipeline):
     """Pipeline emitting per-track tip-trajectory substrate from tracked .slp.
 
-    Reuses existing trait functions DIRECTLY via TraitDef DAG composition —
-    no wrapper module. ``tip_displacement_net`` delegates to
-    ``sleap_roots.bases.get_base_tip_dist``; ``tip_trajectory_length``
-    delegates to ``sleap_roots.lengths.get_root_lengths``. The DAG provides
-    per-track input slicing (``track_first_xy = xy[0]``,
-    ``track_last_xy = xy[-1]``) so existing functions plug in unchanged.
+    Reuses existing trait functions directly via TraitDef DAG composition —
+    no wrapper module. `tip_displacement_net` delegates to
+    `sleap_roots.bases.get_base_tip_dist`; `tip_trajectory_length` delegates
+    to `sleap_roots.lengths.get_root_lengths`. The DAG provides per-track
+    input slicing (`track_first_xy = xy[0]`, `track_last_xy = xy[-1]`) so
+    existing functions plug in unchanged.
 
-    Iteration unit is **per-track** (not per-frame as in DicotPipeline et
-    al.). The pipeline calls ``series.get_tracked_tips()`` to obtain a
-    long-format DataFrame sorted by ``(track_id, frame)``, groups by
-    ``track_id``, and runs the DAG once per group with the per-track inputs.
+    Iteration unit is per-track (not per-frame as in `DicotPipeline` et al.).
+    `compute_tracked_tip_traits` calls `series.get_tracked_tips()` to obtain
+    a long-format DataFrame sorted by `(track_id, frame)`, groups by
+    `track_id`, and runs the DAG once per group with the per-track inputs.
+
+    Attributes:
+        traits: List of `TraitDef` objects (inherited from `Pipeline`,
+            populated from `define_traits()`).
+        trait_map: Dictionary mapping trait names to their definitions
+            (inherited from `Pipeline`).
+        trait_computation_order: List of trait names in topological order
+            (inherited from `Pipeline`).
+
+    Methods:
+        define_traits: Return the per-track TraitDef DAG (5 trait nodes —
+            `track_first_xy`, `track_last_xy`, `tip_displacement_net`,
+            `tip_trajectory_length`, `tracking_coverage`).
+        compute_tracked_tip_traits: Compute per-track traits for one Series
+            and optionally write CSV/JSON outputs.
+        compute_batch_tracked_tip_traits: Run `compute_tracked_tip_traits`
+            across multiple Series and concatenate per-series outputs.
     """
 
     def define_traits(self) -> List[TraitDef]:
         """Return the per-track TraitDef DAG.
 
-        Inputs (pre-populated per track when ``compute_frame_traits`` is
-        called): ``track_xy`` (Nx2 frame-sorted), ``n_frames_tracked``,
-        ``n_frames_total``.
+        Inputs (pre-populated per track when `compute_frame_traits` is
+        called): `track_xy` (Nx2 frame-sorted), `n_frames_tracked`,
+        `n_frames_total`.
         """
         return [
             # Per-track slicing — DAG provides endpoint extraction for the
@@ -179,25 +184,25 @@ class TrackedTipPipeline(Pipeline):
         """Compute per-track tip-trajectory traits for one Series.
 
         Args:
-            series: ``Series`` whose tracked .slp will be processed.
+            series: `Series` whose tracked .slp will be processed.
             write_csv: When True, write the summary CSV and (unless
-                ``emit_trajectories=False``) the trajectory CSV to
-                ``output_dir``.
+                `emit_trajectories=False`) the trajectory CSV to
+                `output_dir`.
             write_json: When True, write the per-series JSON file.
             output_dir: Directory to write outputs to. Created if absent.
             emit_trajectories: When False, suppress writing the trajectory
-                CSV and emit ``trajectories=[]`` in the in-memory and JSON
+                CSV and emit `trajectories=[]` in the in-memory and JSON
                 outputs.
             csv_summary_suffix: Filename suffix for the summary CSV.
             csv_trajectory_suffix: Filename suffix for the trajectory CSV.
             json_suffix: Filename suffix for the JSON.
 
         Returns:
-            A dict with keys ``schema_version`` (1), ``pipeline``
-            (``"TrackedTipPipeline"``), ``units`` (structured dict),
-            ``series`` (str), ``sample_uid`` (str), ``timepoint`` (float or
-            NaN), ``tracks`` (list of per-track dicts), ``trajectories``
-            (list of per-frame dicts; empty when ``emit_trajectories=False``).
+            A dict with keys `schema_version` (1), `pipeline`
+            (`"TrackedTipPipeline"`), `units` (structured dict),
+            `series` (str), `sample_uid` (str), `timepoint` (float or
+            NaN), `tracks` (list of per-track dicts), `trajectories`
+            (list of per-frame dicts; empty when `emit_trajectories=False`).
         """
         # Validate input early — raises ValueError on untracked instances or
         # zero/multiple paths populated without root_type.
@@ -289,8 +294,18 @@ class TrackedTipPipeline(Pipeline):
     ) -> Tuple[pd.DataFrame, Optional[pd.DataFrame]]:
         """Build per-series summary + trajectory DataFrames for CSV emission.
 
-        Returns ``(summary_df, trajectory_df)``. ``trajectory_df`` is ``None``
-        when ``emit_trajectories`` is False.
+        Args:
+            result: Per-series result dict from `compute_tracked_tip_traits`.
+                Must contain `series`, `sample_uid`, `timepoint`, `tracks`,
+                and `trajectories` keys.
+            emit_trajectories: When True, build the trajectory DataFrame.
+                When False, return `None` for the trajectory DataFrame.
+
+        Returns:
+            A tuple `(summary_df, trajectory_df)`. `summary_df` carries the
+            per-track scalar columns with `series` / `sample_uid` /
+            `timepoint` repeated on every row. `trajectory_df` carries the
+            per-frame tip rows (or `None` when `emit_trajectories=False`).
         """
         # Repeat top-level scalars on every row of both DataFrames.
         series_name = result["series"]
@@ -335,17 +350,17 @@ class TrackedTipPipeline(Pipeline):
         json_name: str = "tracked_tip_batch_traits.json",
         emit_trajectories: bool = True,
     ) -> Tuple[pd.DataFrame, Optional[pd.DataFrame], List[Dict[str, Any]]]:
-        """Run ``compute_tracked_tip_traits`` across multiple Series; concatenate.
+        """Run `compute_tracked_tip_traits` across multiple Series; concatenate.
 
-        Mirrors the existing ``compute_batch_plate_traits`` pattern in
-        ``trait_pipelines.py``: walks ``all_series``, calls the per-series
+        Mirrors the existing `compute_batch_plate_traits` pattern in
+        `trait_pipelines.py`: walks `all_series`, calls the per-series
         method, concatenates per-series DataFrames into one, collects
         per-series result dicts into a list.
 
         Args:
-            all_series: Sequence of ``Series`` objects to process.
+            all_series: Sequence of `Series` objects to process.
             write_csv: When True, write batch summary CSV and (unless
-                ``emit_trajectories=False``) batch trajectory CSV.
+                `emit_trajectories=False`) batch trajectory CSV.
             write_json: When True, write a single JSON file containing a
                 list of per-series result dicts.
             output_dir: Directory to write outputs to. Created if absent.
@@ -356,9 +371,9 @@ class TrackedTipPipeline(Pipeline):
                 all series.
 
         Returns:
-            ``(batch_summary_df, batch_trajectory_df_or_None, per_series_results)``.
-            ``batch_trajectory_df_or_None`` is ``None`` when
-            ``emit_trajectories`` is False; otherwise a concatenated
+            `(batch_summary_df, batch_trajectory_df_or_None, per_series_results)`.
+            `batch_trajectory_df_or_None` is `None` when
+            `emit_trajectories` is False; otherwise a concatenated
             DataFrame across all series.
         """
         per_series_results: List[Dict[str, Any]] = []

--- a/sleap_roots/tracked_tip_pipeline.py
+++ b/sleap_roots/tracked_tip_pipeline.py
@@ -32,7 +32,12 @@ _TRACKED_TIP_UNITS: Dict[str, str] = {
 
 _SCHEMA_VERSION = 1
 
-_SUMMARY_COLUMNS: List[str] = [
+# Column orderings are tuples (not lists) so they cannot be mutated by
+# downstream callers. Pandas does not copy the iterable passed to the
+# `columns=` argument; mutation would silently leak across pipeline calls.
+# Matches the convention `_VALID_ROOT_TYPES = ("primary", "lateral", "crown")`
+# in sleap_roots/series.py.
+_SUMMARY_COLUMNS: Tuple[str, ...] = (
     "series",
     "sample_uid",
     "timepoint",
@@ -42,8 +47,8 @@ _SUMMARY_COLUMNS: List[str] = [
     "tracking_coverage",
     "tip_trajectory_length",
     "tip_displacement_net",
-]
-_TRAJECTORY_COLUMNS: List[str] = [
+)
+_TRAJECTORY_COLUMNS: Tuple[str, ...] = (
     "series",
     "sample_uid",
     "timepoint",
@@ -51,7 +56,7 @@ _TRAJECTORY_COLUMNS: List[str] = [
     "frame",
     "tip_x",
     "tip_y",
-]
+)
 
 
 def _get_first_xy(xy: np.ndarray) -> np.ndarray:

--- a/sleap_roots/tracked_tip_pipeline.py
+++ b/sleap_roots/tracked_tip_pipeline.py
@@ -54,6 +54,38 @@ _TRAJECTORY_COLUMNS: List[str] = [
 ]
 
 
+def _get_first_xy(xy: np.ndarray) -> np.ndarray:
+    """Return the first row of an `(N, 2)` xy array.
+
+    Used as a TraitDef function in `TrackedTipPipeline.define_traits`.
+    Defined at module level (not as an inline lambda) so that the pipeline's
+    trait list is picklable, which is a precondition for any future
+    `multiprocessing`-based parallelization of the trait DAG.
+
+    Args:
+        xy: An `(N, 2)` array of frame-sorted `(tip_x, tip_y)` rows.
+
+    Returns:
+        The first row, shape `(2,)`.
+    """
+    return xy[0]
+
+
+def _get_last_xy(xy: np.ndarray) -> np.ndarray:
+    """Return the last row of an `(N, 2)` xy array.
+
+    Module-level (not lambda) for picklability. See `_get_first_xy` for
+    rationale.
+
+    Args:
+        xy: An `(N, 2)` array of frame-sorted `(tip_x, tip_y)` rows.
+
+    Returns:
+        The last row, shape `(2,)`.
+    """
+    return xy[-1]
+
+
 def _tracking_coverage_fn(n_tracked: int, n_total: int) -> float:
     """Compute the fraction of frames in which a track has an instance.
 
@@ -117,7 +149,7 @@ class TrackedTipPipeline(Pipeline):
             # existing distance function below.
             TraitDef(
                 name="track_first_xy",
-                fn=lambda xy: xy[0],
+                fn=_get_first_xy,
                 input_traits=["track_xy"],
                 scalar=False,
                 include_in_csv=False,
@@ -125,7 +157,7 @@ class TrackedTipPipeline(Pipeline):
             ),
             TraitDef(
                 name="track_last_xy",
-                fn=lambda xy: xy[-1],
+                fn=_get_last_xy,
                 input_traits=["track_xy"],
                 scalar=False,
                 include_in_csv=False,

--- a/tests/data/circumnutation_plate/README.md
+++ b/tests/data/circumnutation_plate/README.md
@@ -1,0 +1,78 @@
+# `circumnutation_plate` test fixture
+
+## Purpose
+
+Real-data input fixture for `TrackedTipPipeline` integration tests (issue #129, OpenSpec change `add-tracked-tip-pipeline`). Exercises the full pipeline path on tracked SLEAP predictions from a real circumnutation plate experiment.
+
+## Imaging geometry
+
+- One agar plate, 6 plants per plate, top-down imaging.
+- ~5h imaging window at ~10-min intervals → 311 frames.
+- Single-node skeleton (`['r0']`) — only the primary-root tip is annotated and tracked. The pipeline supports multi-node skeletons too, but this fixture is the minimal case (one node = the tip).
+- Image filenames carry datetime stamps (e.g. `_set1_day1_20250730-212631_001.tif`); the per-frame timestamp / source-filename metadata is intentionally NOT shipped with this fixture (deferred to issue #186).
+
+## Acquisition context
+
+- Experiment: `20250819_Suyash_Patil_CMTN_Kitx_vs_Hk1-3_07-30-25`
+- Acquisition date: 2025-07-30 — 2025-07-31
+- Researcher: Suyash Patil (Talmo Lab / Busch Lab, Salk Institute, Harnessing Plants Initiative)
+- Genotype: KitaakeX (rice, _Oryza sativa_ Kitaake-X background)
+- Treatment: MOCK (control)
+- Imaging substrate: 1/2 MS (0.6% Phytagel)
+- Plate-level metadata also includes 3 sibling plates (KitaakeX × 1uM PAC, hk1-3 × MOCK, hk1-3 × 1uM GA3) — only plate 1 is used for this fixture; the others are not committed.
+
+## Contents
+
+| File | Size | Tracked via | Description |
+|---|---|---|---|
+| `plate_001_greyscale.tracked.slp` | 184 KB | Git LFS | Tracked SLEAP predictions: 311 frames, 6 tracks (`track_0` … `track_5`), single-node skeleton, HDF5 video backend (the .h5 file itself is NOT shipped — sleap-io only opens the .slp directly for trait extraction in our pipeline; image-based code paths require the `.h5` separately). All instances are tracked (zero untracked anywhere — verified during the brainstorm for #129). |
+| `fixture_metadata.csv` | <1 KB | (regular text file) | Synthesized plate-level metadata, single row, `plant_qr_code="plate_001"`. Provides `Series.sample_uid` / `Series.timepoint` lookup support for the WITH-CSV integration test. |
+| `README.md` | this file | (regular text file) | Fixture documentation. |
+
+## Conversion provenance — source → fixture
+
+### `plate_001_greyscale.tracked.slp`
+
+Copied **verbatim, no editing** from:
+```
+Z:\users\eberrigan\circumnutation\20250819_Suyash_Patil_CMTN_Kitx_vs_Hk1-3_07-30-25\run_20250827_091833\plate_001_greyscale.tracked.slp
+```
+
+Originated as the output of an external SLEAP tracking step on the corresponding `plate_001_greyscale.h5` (untracked predictions in `plate_001_greyscale.slp` were tracked downstream into the `.tracked.slp`). The full pipeline that produces the `.h5` from raw `.tif` files (issue #187) is upstream of sleap-roots and not run here.
+
+### `fixture_metadata.csv`
+
+Synthesized **by hand** (one-time, NOT a script — script-driven fixture generation defeats the purpose of frozen test data). Source row from `Z:\users\eberrigan\circumnutation\20250819_Suyash_Patil_CMTN_Kitx_vs_Hk1-3_07-30-25\CMTN_KITXvsHK1-3_META.csv`, plate 1:
+
+```
+plate_number,treatment,num_plants,accesion,num_images,experiment_start,growth_media
+1,MOCK,6,KitaakeX,311,,1/2 MS (0.6% Phytagel)
+```
+
+Mapped to the existing repo CSV convention so `Series.get_metadata` lookups work without modification:
+
+| Source column | Fixture column | Transformation |
+|---|---|---|
+| `plate_number=1` | `plant_qr_code="plate_001"` | Reformatted as `plate_{plate_number:03d}`. **Legacy column-name caveat**: the column is named `plant_qr_code` (the existing convention from cylinder pipelines) but the value here is a PLATE identifier, not a plant identifier. Renaming the column to something like `series_qr_code` is tracked in #163. |
+| `accesion` | `genotype` | Renamed (the source's `accesion` is the cultivar/accession, semantically equivalent to sleap-roots' `genotype` lookup). |
+| `treatment` | `treatment` | Pass-through. |
+| `num_plants=6` | `number_of_plants_cylinder=6` | Reused the existing repo column name. **Misnomer caveat**: there is no cylinder here (this is a plate). Renaming the column is tracked in #163. |
+| (none) | `timepoint=0` | Invented for the fixture — treats this single time-point experiment as `t=0`. The source's `experiment_start` field is empty in CMTN_META and we are not modeling absolute datetime in this fixture. |
+| `num_images, experiment_start, growth_media` | (dropped) | Not needed by `Series.get_metadata` lookups for this PR's tests. |
+
+## Known limitations
+
+- **Per-frame metadata NOT shipped.** The source `run_20250827_091833/plate_001_metadata.csv` (311 rows, one per frame, with `filename, datetime, frame, datetime_str` columns) is **deferred to issue #186** (per-frame metadata accessor on `Series`). This fixture's pipeline tests use integer `frame` indexing only.
+- **HDF5 video file (`plate_001_greyscale.h5`, ~5.7 GB) NOT shipped.** Out of scope for this fixture — sleap-roots' pipeline path opens the .slp directly and does not require the underlying video file. Image-display code paths (e.g. `Series.plot`) require the .h5 and are not exercised by this fixture.
+- **`plant_qr_code` is a misnomer for plate-level data.** The column carries plate identifiers (`plate_001`); the legacy name is preserved for compatibility with the existing `Series.get_metadata` lookup. Rename tracked in #163.
+- **`number_of_plants_cylinder` is a misnomer.** Same legacy reason — the column happens to carry a meaningful "number of plants on this plate" value (6), but the schema name is wrong for plate-tracking experiments. Rename tracked in #163.
+- **Only plate 1 of 4 is committed.** The full experiment has 4 plates (KitaakeX MOCK, hk1-3 GA3, hk1-3 MOCK, KitaakeX PAC). Multi-plate batch testing for `compute_batch_tracked_tip_traits` is exercised with synthetic `.slp` files, not multi-plate real data.
+
+## Related issues
+
+- **#129** — TrackedTipPipeline (this fixture's primary consumer).
+- **#163** — broaden CSV column conventions (will fix `plant_qr_code` and `number_of_plants_cylinder` naming).
+- **#168** — backfill test-data README documentation. This README ships in-PR with #129 (no documentation debt added).
+- **#186** — per-frame metadata accessor on `Series` (will let downstream consumers load the per-frame timestamp CSV).
+- **#187** — preprocessing helpers (image folder → `.h5` + per-frame metadata CSV). Captures the upstream of what produced the source `.h5` and `_metadata.csv` files.
+- **#188** — generic source-META → sleap-roots-CSV converter. Will eventually replace the by-hand synthesis described above.

--- a/tests/data/circumnutation_plate/fixture_metadata.csv
+++ b/tests/data/circumnutation_plate/fixture_metadata.csv
@@ -1,0 +1,2 @@
+plant_qr_code,genotype,treatment,number_of_plants_cylinder,timepoint
+plate_001,KitaakeX,MOCK,6,0

--- a/tests/data/circumnutation_plate/plate_001_greyscale.tracked.slp
+++ b/tests/data/circumnutation_plate/plate_001_greyscale.tracked.slp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf96ef0cfd423073011c2bcc1d3826323195373d2f5668c788aefd9c0c7586aa
+size 184236

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -698,3 +698,437 @@ def test_series_timepoint_raises_on_non_numeric(tmp_path):
     assert "plant1" in msg
     assert "timepoint" in msg
     assert "2024-03-15" in msg
+
+
+# ---------------------------------------------------------------------------
+# Synthetic tracked-`.slp` builder + tests for Series.get_tracked_tips
+# (Section 2 of openspec/changes/add-tracked-tip-pipeline/tasks.md)
+# ---------------------------------------------------------------------------
+
+
+def _build_tracked_slp(
+    tmp_path,
+    series_name: str,
+    n_frames: int,
+    track_positions,
+    *,
+    root_type: str = "primary",
+    skeleton_node_names=("r0",),
+    instance_order_per_frame=None,
+    untracked_at=None,
+    empty_track_name_at=None,
+    other_root_paths=None,
+    csv_content: str = None,
+    sample_uid: str = None,
+):
+    """Build a synthetic tracked .slp and return a `Series`.
+
+    Args:
+        tmp_path: pytest tmp_path fixture.
+        series_name: Series identifier.
+        n_frames: Number of frames in the .slp.
+        track_positions: dict mapping track_name (str) → list of (x, y) tuples
+            of length n_frames. A `None` entry in the list means the track has
+            no instance in that frame (gap).
+        root_type: "primary", "lateral", or "crown" — determines which `*_path`
+            kwarg is set on Series.load.
+        skeleton_node_names: Tuple of node names. The LAST node is treated as
+            the tip by skeleton convention. Default `("r0",)` is the
+            single-node circumnutation skeleton.
+        instance_order_per_frame: Optional list of length `n_frames`, each
+            element a list of track names specifying instance positional order
+            within that frame. Defaults to the dict iteration order. Use this
+            to test the brainstorm-verified track-order non-determinism.
+        untracked_at: Optional list of (frame_idx, track_name) tuples. For each,
+            the corresponding instance is created with track=None instead of a
+            real Track.
+        empty_track_name_at: Optional list of (frame_idx, track_name) tuples.
+            Each gets a Track with name="" (empty string) — should trip the
+            same untracked-instance error path.
+        other_root_paths: Optional dict mapping root-type strings ("primary"/
+            "lateral"/"crown") to None or another tracked .slp path, for
+            testing multi-path-populated cases. None means leave kwarg unset
+            on Series.load.
+        csv_content: Optional CSV text to write to a sidecar.
+        sample_uid: Optional sample_uid kwarg for Series.load.
+
+    Returns:
+        A `Series` loaded via `Series.load`.
+    """
+    Path(tmp_path).mkdir(parents=True, exist_ok=True)
+    image_h, image_w = 200, 200
+    img_array = np.zeros((image_h, image_w), dtype=np.uint8)
+    tif_path = tmp_path / f"{series_name}.tif"
+    from PIL import Image
+
+    Image.fromarray(img_array).save(tif_path.as_posix(), dpi=(72, 72))
+    video = sio.Video.from_filename(tif_path.as_posix())
+
+    skeleton = sio.Skeleton(nodes=[sio.Node(n) for n in skeleton_node_names])
+    n_nodes = len(skeleton_node_names)
+    untracked_set = set(untracked_at or [])
+    empty_name_set = set(empty_track_name_at or [])
+    tracks_by_name = {name: sio.Track(name=name) for name in track_positions.keys()}
+
+    labeled_frames = []
+    for frame_idx in range(n_frames):
+        if instance_order_per_frame is not None:
+            order = instance_order_per_frame[frame_idx]
+        else:
+            order = list(track_positions.keys())
+
+        instances = []
+        for track_name in order:
+            xy = track_positions[track_name][frame_idx]
+            if xy is None:
+                continue  # track has a gap in this frame
+            # Build the (n_nodes, 2) point array — replicate the (x, y) at
+            # every node for multi-node skeletons (the [-1] tip convention
+            # picks up the last node identically regardless).
+            pts = np.tile(np.asarray(xy, dtype=float), (n_nodes, 1))
+
+            if (frame_idx, track_name) in untracked_set:
+                track_arg = None
+            elif (frame_idx, track_name) in empty_name_set:
+                track_arg = sio.Track(name="")
+            else:
+                track_arg = tracks_by_name[track_name]
+
+            inst = sio.Instance.from_numpy(pts, skeleton=skeleton, track=track_arg)
+            instances.append(inst)
+
+        labeled_frames.append(
+            sio.LabeledFrame(video=video, frame_idx=frame_idx, instances=instances)
+        )
+
+    labels = sio.Labels(
+        labeled_frames=labeled_frames,
+        skeletons=[skeleton],
+        videos=[video],
+        tracks=list(tracks_by_name.values()),
+    )
+
+    slp_path = tmp_path / f"{series_name}.{root_type}.tracked.slp"
+    sio.save_slp(labels, slp_path.as_posix())
+
+    csv_path = None
+    if csv_content is not None:
+        csv_path = tmp_path / f"{series_name}.csv"
+        csv_path.write_text(csv_content)
+
+    load_kwargs = {
+        "series_name": series_name,
+        f"{root_type}_path": slp_path.as_posix(),
+        "csv_path": csv_path.as_posix() if csv_path else None,
+        "sample_uid": sample_uid,
+    }
+    if other_root_paths:
+        for k, v in other_root_paths.items():
+            load_kwargs[f"{k}_path"] = v
+    return Series.load(**load_kwargs)
+
+
+def test_get_tracked_tips_returns_long_dataframe(tmp_path):
+    """§2.2: synthetic 3-frame, 2-track .slp → DataFrame with expected cols + 6 rows."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=3,
+        track_positions={
+            "track_a": [(10.0, 20.0), (11.0, 21.0), (12.0, 22.0)],
+            "track_b": [(30.0, 40.0), (31.0, 41.0), (32.0, 42.0)],
+        },
+    )
+    df = series.get_tracked_tips()
+    assert list(df.columns) == ["track_id", "frame", "tip_x", "tip_y"]
+    assert len(df) == 6
+
+
+def test_get_tracked_tips_sorted_by_track_then_frame(tmp_path):
+    """§2.3: instance positional order randomized per frame → output is frame-sorted within each track."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=3,
+        track_positions={
+            "track_a": [(0.0, 0.0), (1.0, 0.0), (2.0, 0.0)],
+            "track_b": [(10.0, 10.0), (11.0, 10.0), (12.0, 10.0)],
+        },
+        instance_order_per_frame=[
+            ["track_a", "track_b"],
+            ["track_b", "track_a"],
+            ["track_b", "track_a"],
+        ],
+    )
+    df = series.get_tracked_tips()
+    # Within each track group, frame is monotonically increasing.
+    for track_id, group in df.groupby("track_id"):
+        assert list(group["frame"]) == sorted(group["frame"])
+    # Output equals its (track_id, frame)-sorted version.
+    expected = df.sort_values(["track_id", "frame"]).reset_index(drop=True)
+    pd.testing.assert_frame_equal(df, expected)
+
+
+def test_get_tracked_tips_auto_detects_root_type_from_populated_path(tmp_path):
+    """§2.4: only primary_path populated → no root_type kwarg needed."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=2,
+        track_positions={"t": [(0.0, 0.0), (1.0, 1.0)]},
+        root_type="primary",
+    )
+    df = series.get_tracked_tips()  # no root_type kwarg
+    assert len(df) == 2
+
+
+def test_get_tracked_tips_raises_when_multiple_paths_populated_no_root_type(tmp_path):
+    """§2.5: primary + lateral populated, no root_type → ValueError mentioning root_type."""
+    # Build two separate tracked .slp files and load them as a single Series.
+    s_primary = _build_tracked_slp(
+        tmp_path / "p",
+        "s",
+        n_frames=1,
+        track_positions={"t": [(0.0, 0.0)]},
+        root_type="primary",
+    )
+    s_lateral = _build_tracked_slp(
+        tmp_path / "l",
+        "s",
+        n_frames=1,
+        track_positions={"t": [(0.0, 0.0)]},
+        root_type="lateral",
+    )
+    series = Series.load(
+        series_name="s",
+        primary_path=s_primary.primary_path,
+        lateral_path=s_lateral.lateral_path,
+    )
+    with pytest.raises(ValueError) as excinfo:
+        series.get_tracked_tips()
+    assert "root_type" in str(excinfo.value)
+
+
+def test_get_tracked_tips_raises_when_zero_paths_populated():
+    """§2.6: no paths populated → ValueError mentioning root_type."""
+    series = Series(series_name="s")
+    with pytest.raises(ValueError) as excinfo:
+        series.get_tracked_tips()
+    assert "root_type" in str(excinfo.value)
+
+
+def test_get_tracked_tips_raises_on_untracked_instance(tmp_path):
+    """§2.7: instance with track=None → ValueError mentioning frame index + sleap.ai/tracking URL."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=3,
+        track_positions={
+            "track_a": [(0.0, 0.0), (1.0, 0.0), (2.0, 0.0)],
+            "track_b": [(10.0, 10.0), (11.0, 10.0), (12.0, 10.0)],
+        },
+        untracked_at=[(1, "track_b")],  # frame 1, track_b is untracked
+    )
+    with pytest.raises(ValueError) as excinfo:
+        series.get_tracked_tips()
+    msg = str(excinfo.value)
+    assert "1" in msg
+    assert "sleap.ai" in msg
+
+
+def test_get_tracked_tips_raises_on_empty_track_name(tmp_path):
+    """§2.8: instance with empty Track.name → same ValueError as track=None."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=2,
+        track_positions={"t": [(0.0, 0.0), (1.0, 1.0)]},
+        empty_track_name_at=[(0, "t")],  # frame 0, track t has empty name
+    )
+    with pytest.raises(ValueError) as excinfo:
+        series.get_tracked_tips()
+    assert "0" in str(excinfo.value)
+
+
+def test_get_tracked_tips_single_node_skeleton(tmp_path):
+    """§2.9: single-node skeleton ['r0'] — tip_x/tip_y are the node coordinates."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=2,
+        track_positions={"t": [(5.5, 7.5), (10.5, 20.5)]},
+        skeleton_node_names=("r0",),  # 1-node skeleton
+    )
+    df = series.get_tracked_tips()
+    assert df.iloc[0]["tip_x"] == 5.5
+    assert df.iloc[0]["tip_y"] == 7.5
+    assert df.iloc[1]["tip_x"] == 10.5
+    assert df.iloc[1]["tip_y"] == 20.5
+
+
+def test_get_tracked_tips_multi_node_skeleton(tmp_path):
+    """§2.10: multi-node skeleton ['base','mid','tip'] — tip_x/tip_y are LAST node coords."""
+    image_h, image_w = 200, 200
+    img_array = np.zeros((image_h, image_w), dtype=np.uint8)
+    tif_path = tmp_path / "s.tif"
+    from PIL import Image
+
+    Image.fromarray(img_array).save(tif_path.as_posix(), dpi=(72, 72))
+    video = sio.Video.from_filename(tif_path.as_posix())
+    skeleton = sio.Skeleton(nodes=[sio.Node("base"), sio.Node("mid"), sio.Node("tip")])
+    track = sio.Track(name="t")
+
+    # Build one frame with one track. Skeleton: base=(1,1), mid=(2,2), tip=(99,99).
+    pts = np.array([[1.0, 1.0], [2.0, 2.0], [99.0, 99.0]])
+    inst = sio.Instance.from_numpy(pts, skeleton=skeleton, track=track)
+    lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[inst])
+    labels = sio.Labels(
+        labeled_frames=[lf], skeletons=[skeleton], videos=[video], tracks=[track]
+    )
+    slp_path = tmp_path / "s.primary.tracked.slp"
+    sio.save_slp(labels, slp_path.as_posix())
+
+    series = Series.load(series_name="s", primary_path=slp_path.as_posix())
+    df = series.get_tracked_tips()
+    # The LAST node (tip=99,99), NOT base or mid.
+    assert df.iloc[0]["tip_x"] == 99.0
+    assert df.iloc[0]["tip_y"] == 99.0
+
+
+# ---------------------------------------------------------------------------
+# Tests for validate_tracked_slp + validate_series_for_tracked_tip
+# (Section 4 of openspec/changes/add-tracked-tip-pipeline/tasks.md)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_tracked_slp_passes_on_fully_tracked(tmp_path):
+    """§4.1: every instance tracked → returns None, no raise."""
+    from sleap_roots.series import validate_tracked_slp
+
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=3,
+        track_positions={"t": [(0.0, 0.0), (1.0, 1.0), (2.0, 2.0)]},
+    )
+    assert validate_tracked_slp(series.primary_path) is None
+
+
+def test_validate_tracked_slp_raises_on_untracked_instance(tmp_path):
+    """§4.2: one untracked instance → ValueError mentioning frame index + sleap.ai/tracking URL."""
+    from sleap_roots.series import validate_tracked_slp
+
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=3,
+        track_positions={
+            "ta": [(0.0, 0.0), (1.0, 0.0), (2.0, 0.0)],
+            "tb": [(10.0, 10.0), (11.0, 10.0), (12.0, 10.0)],
+        },
+        untracked_at=[(2, "tb")],
+    )
+    with pytest.raises(ValueError) as excinfo:
+        validate_tracked_slp(series.primary_path)
+    msg = str(excinfo.value)
+    assert "2" in msg
+    assert "sleap.ai" in msg
+
+
+def test_validate_tracked_slp_lists_all_offending_frames(tmp_path):
+    """§4.3: 3 untracked instances on 3 frames → error message lists all 3."""
+    from sleap_roots.series import validate_tracked_slp
+
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=20,
+        track_positions={"t": [(float(i), float(i)) for i in range(20)]},
+        untracked_at=[(2, "t"), (7, "t"), (15, "t")],
+    )
+    with pytest.raises(ValueError) as excinfo:
+        validate_tracked_slp(series.primary_path)
+    msg = str(excinfo.value)
+    assert "2" in msg
+    assert "7" in msg
+    assert "15" in msg
+
+
+def test_validate_series_for_tracked_tip_resolves_root_type(tmp_path):
+    """§4.4: only primary_path populated → no root_type kwarg needed."""
+    from sleap_roots.series import validate_series_for_tracked_tip
+
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=2,
+        track_positions={"t": [(0.0, 0.0), (1.0, 1.0)]},
+    )
+    assert validate_series_for_tracked_tip(series) is None
+
+
+def test_validate_series_for_tracked_tip_explicit_root_type(tmp_path):
+    """§4.5: primary + lateral both valid; explicit root_type validates the chosen path."""
+    from sleap_roots.series import validate_series_for_tracked_tip
+
+    s_primary = _build_tracked_slp(
+        tmp_path / "p",
+        "s",
+        n_frames=1,
+        track_positions={"t": [(0.0, 0.0)]},
+        root_type="primary",
+    )
+    s_lateral = _build_tracked_slp(
+        tmp_path / "l",
+        "s",
+        n_frames=1,
+        track_positions={"t": [(0.0, 0.0)]},
+        root_type="lateral",
+    )
+    series = Series.load(
+        series_name="s",
+        primary_path=s_primary.primary_path,
+        lateral_path=s_lateral.lateral_path,
+    )
+    assert validate_series_for_tracked_tip(series, root_type="primary") is None
+    assert validate_series_for_tracked_tip(series, root_type="lateral") is None
+
+
+def test_validate_series_for_tracked_tip_raises_on_zero_paths_no_root_type():
+    """§4.6 part 1: zero paths populated → ValueError mentioning root_type."""
+    from sleap_roots.series import validate_series_for_tracked_tip
+
+    series = Series(series_name="s")
+    with pytest.raises(ValueError) as excinfo:
+        validate_series_for_tracked_tip(series)
+    assert "root_type" in str(excinfo.value)
+
+
+def test_validate_series_for_tracked_tip_raises_on_multiple_paths_no_root_type(
+    tmp_path,
+):
+    """§4.6 part 2: multiple paths populated, no root_type → ValueError mentioning root_type."""
+    from sleap_roots.series import validate_series_for_tracked_tip
+
+    s_primary = _build_tracked_slp(
+        tmp_path / "p",
+        "s",
+        n_frames=1,
+        track_positions={"t": [(0.0, 0.0)]},
+        root_type="primary",
+    )
+    s_lateral = _build_tracked_slp(
+        tmp_path / "l",
+        "s",
+        n_frames=1,
+        track_positions={"t": [(0.0, 0.0)]},
+        root_type="lateral",
+    )
+    series = Series.load(
+        series_name="s",
+        primary_path=s_primary.primary_path,
+        lateral_path=s_lateral.lateral_path,
+    )
+    with pytest.raises(ValueError) as excinfo:
+        validate_series_for_tracked_tip(series)
+    assert "root_type" in str(excinfo.value)

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -870,16 +870,28 @@ def test_get_tracked_tips_sorted_by_track_then_frame(tmp_path):
 
 
 def test_get_tracked_tips_auto_detects_root_type_from_populated_path(tmp_path):
-    """§2.4: only primary_path populated → no root_type kwarg needed."""
+    """§2.4: only primary_path populated → no root_type kwarg needed.
+
+    Strengthened per /review-pr feedback: assert specific xy values to
+    verify the impl actually read the primary path. The previous version
+    only checked `len(df) == 2`, which would also pass if the impl
+    accidentally read a different (empty) path.
+    """
     series = _build_tracked_slp(
         tmp_path,
         "s",
         n_frames=2,
-        track_positions={"t": [(0.0, 0.0), (1.0, 1.0)]},
+        track_positions={"t": [(7.5, 8.5), (9.5, 10.5)]},
         root_type="primary",
     )
     df = series.get_tracked_tips()  # no root_type kwarg
     assert len(df) == 2
+    # Verify the values came from the primary path, not silently from
+    # somewhere else.
+    assert df.iloc[0]["tip_x"] == 7.5
+    assert df.iloc[0]["tip_y"] == 8.5
+    assert df.iloc[1]["tip_x"] == 9.5
+    assert df.iloc[1]["tip_y"] == 10.5
 
 
 def test_get_tracked_tips_raises_when_multiple_paths_populated_no_root_type(tmp_path):

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1104,6 +1104,38 @@ def test_validate_series_for_tracked_tip_raises_on_zero_paths_no_root_type():
     assert "root_type" in str(excinfo.value)
 
 
+def test_get_tracked_tips_raises_on_invalid_root_type(tmp_path):
+    """Invalid root_type string (e.g. 'foo') → user-facing ValueError, not KeyError."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=2,
+        track_positions={"t": [(0.0, 0.0), (1.0, 1.0)]},
+    )
+    with pytest.raises(ValueError) as excinfo:
+        series.get_tracked_tips(root_type="foo")
+    msg = str(excinfo.value)
+    assert "foo" in msg
+    assert "primary" in msg  # error lists valid options
+
+
+def test_validate_series_for_tracked_tip_raises_on_invalid_root_type(tmp_path):
+    """Invalid root_type string (e.g. 'foo') → user-facing ValueError, not KeyError."""
+    from sleap_roots.series import validate_series_for_tracked_tip
+
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=2,
+        track_positions={"t": [(0.0, 0.0), (1.0, 1.0)]},
+    )
+    with pytest.raises(ValueError) as excinfo:
+        validate_series_for_tracked_tip(series, root_type="foo")
+    msg = str(excinfo.value)
+    assert "foo" in msg
+    assert "primary" in msg
+
+
 def test_validate_series_for_tracked_tip_raises_on_multiple_paths_no_root_type(
     tmp_path,
 ):

--- a/tests/test_tracked_tip_pipeline.py
+++ b/tests/test_tracked_tip_pipeline.py
@@ -731,6 +731,105 @@ def test_compute_batch_tracked_tip_traits_emit_trajectories_false(tmp_path):
     assert not (out_dir / "tracked_tip_batch_trajectories.csv").exists()
 
 
+def test_compute_batch_tracked_tip_traits_returns_tuple_shape(tmp_path):
+    """compute_batch_* returns (summary_df, Optional[trajectory_df], List[Dict]).
+
+    Per /review-pr feedback: existing tests only inspected on-disk files
+    from the batch method. The return tuple shape (especially the
+    `None` case for `emit_trajectories=False`) was uncovered.
+    """
+    serieses = [
+        _build_tracked_slp(
+            tmp_path / f"d{i}",
+            f"s{i}",
+            n_frames=2,
+            track_positions={"t": [(0.0, 0.0), (1.0, 1.0)]},
+        )
+        for i in range(3)
+    ]
+    # With emit_trajectories=True (default).
+    summary_df, trajectory_df, results = (
+        TrackedTipPipeline().compute_batch_tracked_tip_traits(serieses)
+    )
+    assert isinstance(summary_df, pd.DataFrame)
+    assert len(summary_df) == 3  # 1 track per series x 3 series
+    assert isinstance(trajectory_df, pd.DataFrame)
+    assert len(trajectory_df) == 6  # 2 frames x 1 track x 3 series
+    assert isinstance(results, list)
+    assert len(results) == 3
+    for r in results:
+        assert "tracks" in r and "trajectories" in r
+
+    # With emit_trajectories=False — trajectory_df MUST be None (not an
+    # empty DataFrame).
+    (
+        summary_df,
+        trajectory_df,
+        results,
+    ) = TrackedTipPipeline().compute_batch_tracked_tip_traits(
+        serieses, emit_trajectories=False
+    )
+    assert isinstance(summary_df, pd.DataFrame)
+    assert len(summary_df) == 3
+    assert trajectory_df is None
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+
+def test_compute_tracked_tip_traits_writes_csv_with_zero_tracks(tmp_path):
+    """Zero-track .slp + write_csv=True → header-only summary CSV, no crash.
+
+    Per /review-pr feedback: the zero-track in-memory case was tested
+    (`test_compute_tracked_tip_traits_zero_tracks`) but the CSV-emission
+    side wasn't. Verify the summary CSV is written, parses, and has
+    the expected column header but zero data rows.
+    """
+    Path(tmp_path).mkdir(parents=True, exist_ok=True)
+    image_h, image_w = 200, 200
+    img_array = np.zeros((image_h, image_w), dtype=np.uint8)
+    tif_path = tmp_path / "s.tif"
+    from PIL import Image
+
+    Image.fromarray(img_array).save(tif_path.as_posix(), dpi=(72, 72))
+    video = sio.Video.from_filename(tif_path.as_posix())
+    skeleton = sio.Skeleton(nodes=[sio.Node("r0")])
+    labeled_frames = [
+        sio.LabeledFrame(video=video, frame_idx=i, instances=[]) for i in range(3)
+    ]
+    labels = sio.Labels(
+        labeled_frames=labeled_frames,
+        skeletons=[skeleton],
+        videos=[video],
+        tracks=[],
+    )
+    slp_path = tmp_path / "s.primary.tracked.slp"
+    sio.save_slp(labels, slp_path.as_posix())
+    series = Series.load(series_name="s", primary_path=slp_path.as_posix())
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    TrackedTipPipeline().compute_tracked_tip_traits(
+        series, write_csv=True, output_dir=out_dir.as_posix()
+    )
+
+    summary_path = out_dir / "s.tracked_tip_traits.csv"
+    assert summary_path.exists()
+    df = pd.read_csv(summary_path)
+    assert len(df) == 0  # zero data rows
+    # Column header still present and correctly ordered.
+    assert list(df.columns) == [
+        "series",
+        "sample_uid",
+        "timepoint",
+        "track_id",
+        "n_frames_tracked",
+        "n_frames_total",
+        "tracking_coverage",
+        "tip_trajectory_length",
+        "tip_displacement_net",
+    ]
+
+
 def test_compute_batch_tracked_tip_traits_empty_input(tmp_path):
     """§10.5: empty list → empty outputs, no crash."""
     out_dir = tmp_path / "batch_out"

--- a/tests/test_tracked_tip_pipeline.py
+++ b/tests/test_tracked_tip_pipeline.py
@@ -9,6 +9,7 @@ Reuses the synthetic-tracked-`.slp` builder ``_build_tracked_slp`` from
 """
 
 import json
+import pickle
 from pathlib import Path
 
 import numpy as np
@@ -276,6 +277,36 @@ def test_compute_tracked_tip_traits_zero_tracks(tmp_path):
     result = TrackedTipPipeline().compute_tracked_tip_traits(series)
     assert result["tracks"] == []
     assert result["trajectories"] == []
+
+
+def test_pipeline_traits_list_pickles_cleanly():
+    """TraitDef `fn` values SHALL be picklable (no inline lambdas).
+
+    Surfaced by /review-pr on PR #190: the original implementation used
+    inline lambdas (`fn=lambda xy: xy[0]`) for per-track slicing, which
+    are not picklable. Picklability is a precondition for any future
+    `multiprocessing`-based parallelization of the trait DAG.
+
+    This test asserts:
+      1. `pickle.dumps(pipeline.traits)` succeeds.
+      2. The round-tripped traits list has the same length and same
+         per-trait names as the original.
+      3. Every individual `trait_def.fn` is picklable on its own.
+    """
+    pipeline = TrackedTipPipeline()
+    blob = pickle.dumps(pipeline.traits)
+    assert isinstance(blob, bytes)
+    assert len(blob) > 0
+
+    restored = pickle.loads(blob)
+    assert len(restored) == len(pipeline.traits)
+    assert [t.name for t in restored] == [t.name for t in pipeline.traits]
+
+    for trait_def in pipeline.traits:
+        fn_blob = pickle.dumps(trait_def.fn)
+        assert isinstance(
+            fn_blob, bytes
+        ), f"TraitDef '{trait_def.name}' fn={trait_def.fn!r} did not pickle."
 
 
 def test_tracking_coverage_bounded_when_track_has_duplicate_frame(tmp_path):

--- a/tests/test_tracked_tip_pipeline.py
+++ b/tests/test_tracked_tip_pipeline.py
@@ -1,0 +1,728 @@
+"""Tests for TrackedTipPipeline (issue #129, OpenSpec change add-tracked-tip-pipeline).
+
+Section 6 (pipeline DAG composition), Section 8 (file emission), Section 10
+(batch method), Section 12 (real-fixture integration) of the change's
+``tasks.md``.
+
+Reuses the synthetic-tracked-`.slp` builder ``_build_tracked_slp`` from
+``tests.test_series`` to avoid duplication.
+"""
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import sleap_io as sio
+
+from sleap_roots import Series, TrackedTipPipeline
+from tests.test_series import _build_tracked_slp
+
+
+# ---------------------------------------------------------------------------
+# §6 — DAG composition tests (in-memory result dict, no file I/O)
+# ---------------------------------------------------------------------------
+
+
+def test_compute_tracked_tip_traits_returns_expected_dict_keys(tmp_path):
+    """§6.2: result dict has exactly the expected top-level keys."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=5,
+        track_positions={
+            "track_a": [(float(i), 0.0) for i in range(5)],
+            "track_b": [(float(i), 10.0) for i in range(5)],
+        },
+    )
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+    assert set(result.keys()) == {
+        "schema_version",
+        "pipeline",
+        "units",
+        "series",
+        "sample_uid",
+        "timepoint",
+        "tracks",
+        "trajectories",
+    }
+
+
+def test_compute_tracked_tip_traits_schema_version_is_1(tmp_path):
+    """§6.3: schema_version is 1 for the initial release."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=2,
+        track_positions={"t": [(0.0, 0.0), (1.0, 1.0)]},
+    )
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+    assert result["schema_version"] == 1
+
+
+def test_compute_tracked_tip_traits_pipeline_name(tmp_path):
+    """Pipeline string identifier."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=2,
+        track_positions={"t": [(0.0, 0.0), (1.0, 1.0)]},
+    )
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+    assert result["pipeline"] == "TrackedTipPipeline"
+
+
+def test_compute_tracked_tip_traits_units_dict(tmp_path):
+    """§6.4: units dict has exactly the expected keys/values."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=2,
+        track_positions={"t": [(0.0, 0.0), (1.0, 1.0)]},
+    )
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+    assert result["units"] == {
+        "lengths": "pixels",
+        "ratios": "dimensionless",
+        "counts": "dimensionless",
+        "time": "unspecified",
+    }
+
+
+def test_compute_tracked_tip_traits_tracks_table_one_row_per_track_id(tmp_path):
+    """§6.5: 2-track .slp → exactly 2 rows in tracks; row keys are exact set."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=3,
+        track_positions={
+            "track_a": [(0.0, 0.0), (1.0, 0.0), (2.0, 0.0)],
+            "track_b": [(10.0, 10.0), (11.0, 10.0), (12.0, 10.0)],
+        },
+    )
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+    assert len(result["tracks"]) == 2
+    expected_keys = {
+        "track_id",
+        "n_frames_tracked",
+        "n_frames_total",
+        "tracking_coverage",
+        "tip_trajectory_length",
+        "tip_displacement_net",
+    }
+    for row in result["tracks"]:
+        assert set(row.keys()) == expected_keys
+
+
+def test_compute_tracked_tip_traits_trajectories_table_one_row_per_track_frame(
+    tmp_path,
+):
+    """§6.6: 5×2 fully-tracked → 10 trajectory rows."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=5,
+        track_positions={
+            "track_a": [(float(i), 0.0) for i in range(5)],
+            "track_b": [(float(i), 10.0) for i in range(5)],
+        },
+    )
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+    assert len(result["trajectories"]) == 10
+    # Per-row keys are exact set; top-level scalars NOT repeated in rows.
+    for row in result["trajectories"]:
+        assert set(row.keys()) == {"track_id", "frame", "tip_x", "tip_y"}
+
+
+def test_tip_trajectory_length_straight_line(tmp_path):
+    """§6.7: straight-line trajectory (0,0)→(3,0)→(6,0)→(10,0) → length 10."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=4,
+        track_positions={
+            "t": [(0.0, 0.0), (3.0, 0.0), (6.0, 0.0), (10.0, 0.0)],
+        },
+    )
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+    row = result["tracks"][0]
+    assert row["tip_trajectory_length"] == pytest.approx(10.0)
+
+
+def test_tip_displacement_net_straight_line(tmp_path):
+    """§6.8: same straight-line trajectory → displacement_net == 10.0."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=4,
+        track_positions={
+            "t": [(0.0, 0.0), (3.0, 0.0), (6.0, 0.0), (10.0, 0.0)],
+        },
+    )
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+    row = result["tracks"][0]
+    assert row["tip_displacement_net"] == pytest.approx(10.0)
+
+
+def test_tip_displacement_net_round_trip_returns_to_origin(tmp_path):
+    """§6.9: round-trip (0,0)→(5,0)→(0,0) → displacement=0, length=10. Validates the geometric distinction."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=3,
+        track_positions={
+            "t": [(0.0, 0.0), (5.0, 0.0), (0.0, 0.0)],
+        },
+    )
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+    row = result["tracks"][0]
+    assert row["tip_displacement_net"] == pytest.approx(0.0)
+    assert row["tip_trajectory_length"] == pytest.approx(10.0)
+
+
+def test_tip_displacement_net_right_angle_path(tmp_path):
+    """§6.10: 3-4-5 triangle path (0,0)→(3,0)→(3,4) → length=7, displacement=5."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=3,
+        track_positions={
+            "t": [(0.0, 0.0), (3.0, 0.0), (3.0, 4.0)],
+        },
+    )
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+    row = result["tracks"][0]
+    assert row["tip_trajectory_length"] == pytest.approx(7.0)
+    assert row["tip_displacement_net"] == pytest.approx(5.0)
+
+
+def test_tracking_coverage_full(tmp_path):
+    """§6.11: every frame tracked → coverage == 1.0."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=4,
+        track_positions={"t": [(0.0, 0.0), (1.0, 0.0), (2.0, 0.0), (3.0, 0.0)]},
+    )
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+    row = result["tracks"][0]
+    assert row["tracking_coverage"] == pytest.approx(1.0)
+    assert row["n_frames_tracked"] == 4
+    assert row["n_frames_total"] == 4
+
+
+def test_tracking_coverage_partial(tmp_path):
+    """§6.12: 3 of 5 frames tracked → coverage == 0.6."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=5,
+        track_positions={
+            "t": [(0.0, 0.0), (1.0, 0.0), None, (3.0, 0.0), None],
+        },
+    )
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+    row = result["tracks"][0]
+    assert row["tracking_coverage"] == pytest.approx(0.6)
+    assert row["n_frames_tracked"] == 3
+    assert row["n_frames_total"] == 5
+
+
+def test_compute_tracked_tip_traits_single_frame_track_zero_displacement_nan_length(
+    tmp_path,
+):
+    """§6.13: single-frame track → displacement=0.0, trajectory_length=NaN. Codifies asymmetry."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=10,
+        track_positions={
+            "t": [None] * 4 + [(7.0, 7.0)] + [None] * 5,  # only frame 4 tracked
+        },
+    )
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+    row = result["tracks"][0]
+    assert row["tip_displacement_net"] == pytest.approx(0.0)
+    assert np.isnan(row["tip_trajectory_length"])
+    assert row["n_frames_tracked"] == 1
+    assert row["n_frames_total"] == 10
+
+
+def test_compute_tracked_tip_traits_zero_tracks(tmp_path):
+    """§6.14: empty .slp (no tracked instances anywhere) → empty tracks/trajectories arrays, no crash."""
+    # Build an .slp with frames but ZERO instances per frame.
+    Path(tmp_path).mkdir(parents=True, exist_ok=True)
+    image_h, image_w = 200, 200
+    img_array = np.zeros((image_h, image_w), dtype=np.uint8)
+    tif_path = tmp_path / "s.tif"
+    from PIL import Image
+
+    Image.fromarray(img_array).save(tif_path.as_posix(), dpi=(72, 72))
+    video = sio.Video.from_filename(tif_path.as_posix())
+    skeleton = sio.Skeleton(nodes=[sio.Node("r0")])
+    labeled_frames = [
+        sio.LabeledFrame(video=video, frame_idx=i, instances=[]) for i in range(3)
+    ]
+    labels = sio.Labels(
+        labeled_frames=labeled_frames,
+        skeletons=[skeleton],
+        videos=[video],
+        tracks=[],
+    )
+    slp_path = tmp_path / "s.primary.tracked.slp"
+    sio.save_slp(labels, slp_path.as_posix())
+    series = Series.load(series_name="s", primary_path=slp_path.as_posix())
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+    assert result["tracks"] == []
+    assert result["trajectories"] == []
+
+
+def test_compute_tracked_tip_traits_emits_sample_uid_and_timepoint_from_csv(tmp_path):
+    """§6.15: with CSV → sample_uid and timepoint resolved from CSV."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=2,
+        track_positions={"t": [(0.0, 0.0), (1.0, 1.0)]},
+        csv_content="plant_qr_code,timepoint\nplate_X,2.5\n",
+        sample_uid="plate_X",
+    )
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+    assert result["sample_uid"] == "plate_X"
+    assert result["timepoint"] == 2.5
+
+
+def test_compute_tracked_tip_traits_no_csv_defaults_sample_uid_to_series_name(tmp_path):
+    """§6.16: no CSV → sample_uid defaults to series_name, timepoint NaN."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=2,
+        track_positions={"t": [(0.0, 0.0), (1.0, 1.0)]},
+    )
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+    assert result["sample_uid"] == "s"
+    assert np.isnan(result["timepoint"])
+
+
+def test_track_id_values_match_inst_track_name(tmp_path):
+    """§6.17: custom track names → output track_ids match exactly."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=2,
+        track_positions={
+            "alpha": [(0.0, 0.0), (1.0, 1.0)],
+            "beta": [(2.0, 2.0), (3.0, 3.0)],
+        },
+    )
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+    assert {r["track_id"] for r in result["tracks"]} == {"alpha", "beta"}
+
+
+# ---------------------------------------------------------------------------
+# §8 — file emission tests
+# ---------------------------------------------------------------------------
+
+
+def test_compute_tracked_tip_traits_writes_summary_csv(tmp_path):
+    """§8.1: summary CSV exists with expected columns."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "plate_001",
+        n_frames=2,
+        track_positions={"t": [(0.0, 0.0), (1.0, 1.0)]},
+    )
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    TrackedTipPipeline().compute_tracked_tip_traits(
+        series, write_csv=True, output_dir=out_dir.as_posix()
+    )
+    summary_path = out_dir / "plate_001.tracked_tip_traits.csv"
+    assert summary_path.exists()
+    df = pd.read_csv(summary_path)
+    assert list(df.columns) == [
+        "series",
+        "sample_uid",
+        "timepoint",
+        "track_id",
+        "n_frames_tracked",
+        "n_frames_total",
+        "tracking_coverage",
+        "tip_trajectory_length",
+        "tip_displacement_net",
+    ]
+
+
+def test_compute_tracked_tip_traits_writes_trajectory_csv(tmp_path):
+    """§8.2: trajectory CSV exists with expected columns."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "plate_001",
+        n_frames=2,
+        track_positions={"t": [(0.0, 0.0), (1.0, 1.0)]},
+    )
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    TrackedTipPipeline().compute_tracked_tip_traits(
+        series, write_csv=True, output_dir=out_dir.as_posix()
+    )
+    traj_path = out_dir / "plate_001.tracked_tip_trajectories.csv"
+    assert traj_path.exists()
+    df = pd.read_csv(traj_path)
+    assert list(df.columns) == [
+        "series",
+        "sample_uid",
+        "timepoint",
+        "track_id",
+        "frame",
+        "tip_x",
+        "tip_y",
+    ]
+
+
+def test_compute_tracked_tip_traits_writes_json_with_both_tables(tmp_path):
+    """§8.3: JSON exists, parses, has both tables at top level."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "plate_001",
+        n_frames=2,
+        track_positions={"t": [(0.0, 0.0), (1.0, 1.0)]},
+    )
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    TrackedTipPipeline().compute_tracked_tip_traits(
+        series, write_json=True, output_dir=out_dir.as_posix()
+    )
+    json_path = out_dir / "plate_001.tracked_tip_traits.json"
+    assert json_path.exists()
+    parsed = json.loads(json_path.read_text())
+    assert "tracks" in parsed
+    assert "trajectories" in parsed
+    assert isinstance(parsed["tracks"], list)
+    assert isinstance(parsed["trajectories"], list)
+
+
+def test_compute_tracked_tip_traits_emit_trajectories_false_skips_trajectory_csv(
+    tmp_path,
+):
+    """§8.4: emit_trajectories=False → no trajectory CSV written."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "plate_001",
+        n_frames=2,
+        track_positions={"t": [(0.0, 0.0), (1.0, 1.0)]},
+    )
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    TrackedTipPipeline().compute_tracked_tip_traits(
+        series,
+        write_csv=True,
+        emit_trajectories=False,
+        output_dir=out_dir.as_posix(),
+    )
+    assert (out_dir / "plate_001.tracked_tip_traits.csv").exists()
+    assert not (out_dir / "plate_001.tracked_tip_trajectories.csv").exists()
+
+
+def test_compute_tracked_tip_traits_emit_trajectories_false_omits_trajectories_in_json(
+    tmp_path,
+):
+    """§8.5: emit_trajectories=False with JSON → trajectories array is empty."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "plate_001",
+        n_frames=2,
+        track_positions={"t": [(0.0, 0.0), (1.0, 1.0)]},
+    )
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    TrackedTipPipeline().compute_tracked_tip_traits(
+        series,
+        write_json=True,
+        emit_trajectories=False,
+        output_dir=out_dir.as_posix(),
+    )
+    parsed = json.loads((out_dir / "plate_001.tracked_tip_traits.json").read_text())
+    assert parsed["trajectories"] == []
+    assert len(parsed["tracks"]) == 1
+
+
+def test_compute_tracked_tip_traits_csv_repeats_top_level_scalars_per_row(tmp_path):
+    """§8.6: every CSV row carries series, sample_uid, timepoint."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "plate_001",
+        n_frames=3,
+        track_positions={
+            "ta": [(0.0, 0.0), (1.0, 0.0), (2.0, 0.0)],
+            "tb": [(10.0, 10.0), (11.0, 10.0), (12.0, 10.0)],
+        },
+        csv_content="plant_qr_code,timepoint\nplate_001,5\n",
+        sample_uid="plate_001",
+    )
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    TrackedTipPipeline().compute_tracked_tip_traits(
+        series, write_csv=True, output_dir=out_dir.as_posix()
+    )
+    df_summary = pd.read_csv(out_dir / "plate_001.tracked_tip_traits.csv")
+    assert (df_summary["series"] == "plate_001").all()
+    assert (df_summary["sample_uid"] == "plate_001").all()
+    assert (df_summary["timepoint"] == 5.0).all()
+    df_traj = pd.read_csv(out_dir / "plate_001.tracked_tip_trajectories.csv")
+    assert (df_traj["series"] == "plate_001").all()
+    assert (df_traj["sample_uid"] == "plate_001").all()
+    assert (df_traj["timepoint"] == 5.0).all()
+
+
+def test_compute_tracked_tip_traits_json_top_level_scalars_not_in_per_row(tmp_path):
+    """§8.7: JSON tracks/trajectories rows do NOT carry series/sample_uid/timepoint."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "plate_001",
+        n_frames=2,
+        track_positions={"t": [(0.0, 0.0), (1.0, 1.0)]},
+    )
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    TrackedTipPipeline().compute_tracked_tip_traits(
+        series, write_json=True, output_dir=out_dir.as_posix()
+    )
+    parsed = json.loads((out_dir / "plate_001.tracked_tip_traits.json").read_text())
+    for row in parsed["tracks"]:
+        assert "series" not in row
+        assert "sample_uid" not in row
+        assert "timepoint" not in row
+    for row in parsed["trajectories"]:
+        assert "series" not in row
+        assert "sample_uid" not in row
+        assert "timepoint" not in row
+
+
+def test_compute_tracked_tip_traits_json_nan_to_null(tmp_path):
+    """§8.8: NaN trajectory_length (single-frame) serializes to JSON null."""
+    series = _build_tracked_slp(
+        tmp_path,
+        "s",
+        n_frames=10,
+        track_positions={"t": [None] * 4 + [(7.0, 7.0)] + [None] * 5},
+    )
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    TrackedTipPipeline().compute_tracked_tip_traits(
+        series, write_json=True, output_dir=out_dir.as_posix()
+    )
+    parsed = json.loads((out_dir / "s.tracked_tip_traits.json").read_text())
+    row = parsed["tracks"][0]
+    assert row["tip_trajectory_length"] is None  # JSON null
+    assert row["tip_displacement_net"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# §10 — batch method tests
+# ---------------------------------------------------------------------------
+
+
+def test_compute_batch_tracked_tip_traits_concatenates_summary(tmp_path):
+    """§10.1: 3 series × 2 tracks each → 6 summary rows in concatenated CSV."""
+    serieses = [
+        _build_tracked_slp(
+            tmp_path / f"d{i}",
+            f"s{i}",
+            n_frames=3,
+            track_positions={
+                "ta": [(0.0, 0.0)] * 3,
+                "tb": [(10.0, 10.0)] * 3,
+            },
+        )
+        for i in range(3)
+    ]
+    out_dir = tmp_path / "batch_out"
+    out_dir.mkdir()
+    TrackedTipPipeline().compute_batch_tracked_tip_traits(
+        serieses, write_csv=True, output_dir=out_dir.as_posix()
+    )
+    df = pd.read_csv(out_dir / "tracked_tip_batch_traits.csv")
+    assert len(df) == 6
+
+
+def test_compute_batch_tracked_tip_traits_concatenates_trajectories(tmp_path):
+    """§10.2: 3 series × 5 frames × 2 tracks → 30 trajectory rows."""
+    serieses = [
+        _build_tracked_slp(
+            tmp_path / f"d{i}",
+            f"s{i}",
+            n_frames=5,
+            track_positions={
+                "ta": [(float(j), 0.0) for j in range(5)],
+                "tb": [(float(j), 10.0) for j in range(5)],
+            },
+        )
+        for i in range(3)
+    ]
+    out_dir = tmp_path / "batch_out"
+    out_dir.mkdir()
+    TrackedTipPipeline().compute_batch_tracked_tip_traits(
+        serieses, write_csv=True, output_dir=out_dir.as_posix()
+    )
+    df = pd.read_csv(out_dir / "tracked_tip_batch_trajectories.csv")
+    assert len(df) == 30
+
+
+def test_compute_batch_tracked_tip_traits_writes_json_list(tmp_path):
+    """§10.3: batch JSON parses as list of per-series dicts."""
+    serieses = [
+        _build_tracked_slp(
+            tmp_path / f"d{i}",
+            f"s{i}",
+            n_frames=2,
+            track_positions={"t": [(0.0, 0.0), (1.0, 1.0)]},
+        )
+        for i in range(3)
+    ]
+    out_dir = tmp_path / "batch_out"
+    out_dir.mkdir()
+    TrackedTipPipeline().compute_batch_tracked_tip_traits(
+        serieses, write_json=True, output_dir=out_dir.as_posix()
+    )
+    parsed = json.loads((out_dir / "tracked_tip_batch_traits.json").read_text())
+    assert isinstance(parsed, list)
+    assert len(parsed) == 3
+    for entry in parsed:
+        assert "tracks" in entry
+        assert "trajectories" in entry
+        assert "schema_version" in entry
+
+
+def test_compute_batch_tracked_tip_traits_emit_trajectories_false(tmp_path):
+    """§10.4: batch with emit_trajectories=False → no batch trajectory CSV."""
+    serieses = [
+        _build_tracked_slp(
+            tmp_path / f"d{i}",
+            f"s{i}",
+            n_frames=2,
+            track_positions={"t": [(0.0, 0.0), (1.0, 1.0)]},
+        )
+        for i in range(2)
+    ]
+    out_dir = tmp_path / "batch_out"
+    out_dir.mkdir()
+    TrackedTipPipeline().compute_batch_tracked_tip_traits(
+        serieses,
+        write_csv=True,
+        emit_trajectories=False,
+        output_dir=out_dir.as_posix(),
+    )
+    assert (out_dir / "tracked_tip_batch_traits.csv").exists()
+    assert not (out_dir / "tracked_tip_batch_trajectories.csv").exists()
+
+
+def test_compute_batch_tracked_tip_traits_empty_input(tmp_path):
+    """§10.5: empty list → empty outputs, no crash."""
+    out_dir = tmp_path / "batch_out"
+    out_dir.mkdir()
+    TrackedTipPipeline().compute_batch_tracked_tip_traits(
+        [], write_json=True, output_dir=out_dir.as_posix()
+    )
+    parsed = json.loads((out_dir / "tracked_tip_batch_traits.json").read_text())
+    assert parsed == []
+
+
+# ---------------------------------------------------------------------------
+# §12 — real-fixture integration tests
+# ---------------------------------------------------------------------------
+
+REAL_FIXTURE_SLP = "tests/data/circumnutation_plate/plate_001_greyscale.tracked.slp"
+REAL_FIXTURE_CSV = "tests/data/circumnutation_plate/fixture_metadata.csv"
+
+
+@pytest.mark.skipif(
+    not Path(REAL_FIXTURE_SLP).exists(),
+    reason=f"Real fixture not present: {REAL_FIXTURE_SLP}",
+)
+def test_real_fixture_with_csv_metadata():
+    """§12.1: real fixture + CSV → sample_uid, timepoint, 6 tracks, 1866 trajectory rows."""
+    series = Series.load(
+        series_name="plate_001",
+        primary_path=REAL_FIXTURE_SLP,
+        csv_path=REAL_FIXTURE_CSV,
+        sample_uid="plate_001",
+    )
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+    assert result["sample_uid"] == "plate_001"
+    assert result["timepoint"] == 0.0
+    assert len(result["tracks"]) == 6
+    assert len(result["trajectories"]) == 1866  # 311 frames × 6 tracked instances
+    for row in result["tracks"]:
+        assert 0.0 <= row["tracking_coverage"] <= 1.0
+
+
+@pytest.mark.skipif(
+    not Path(REAL_FIXTURE_SLP).exists(),
+    reason=f"Real fixture not present: {REAL_FIXTURE_SLP}",
+)
+def test_real_fixture_no_csv_metadata():
+    """§12.2: real fixture without CSV → sample_uid defaults, timepoint NaN."""
+    series = Series.load(
+        series_name="plate_001",
+        primary_path=REAL_FIXTURE_SLP,
+    )
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+    assert result["sample_uid"] == "plate_001"
+    assert np.isnan(result["timepoint"])
+    assert len(result["tracks"]) == 6
+    assert len(result["trajectories"]) == 1866
+
+
+@pytest.mark.skipif(
+    not Path(REAL_FIXTURE_SLP).exists(),
+    reason=f"Real fixture not present: {REAL_FIXTURE_SLP}",
+)
+def test_real_fixture_track_id_values():
+    """§12.3: track names are track_0 .. track_5 (verified during brainstorm)."""
+    series = Series.load(
+        series_name="plate_001",
+        primary_path=REAL_FIXTURE_SLP,
+    )
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+    track_ids = {row["track_id"] for row in result["tracks"]}
+    assert track_ids == {
+        "track_0",
+        "track_1",
+        "track_2",
+        "track_3",
+        "track_4",
+        "track_5",
+    }
+
+
+@pytest.mark.skipif(
+    not Path(REAL_FIXTURE_SLP).exists(),
+    reason=f"Real fixture not present: {REAL_FIXTURE_SLP}",
+)
+def test_real_fixture_track_order_non_determinism_handled():
+    """§12.4: positional order differs across frames in source — pipeline still groups correctly."""
+    labels = sio.load_slp(REAL_FIXTURE_SLP)
+    # Confirm the brainstorm-verified non-determinism: frame 0 vs frame 1
+    # have different positional ordering of track names.
+    f0_order = [inst.track.name for inst in labels.labeled_frames[0].instances]
+    f1_order = [inst.track.name for inst in labels.labeled_frames[1].instances]
+    assert f0_order != f1_order, (
+        "Real fixture should have non-deterministic track-positional order "
+        "across frames; if this assertion fails, the fixture data has "
+        "changed."
+    )
+
+    # The pipeline groups correctly regardless.
+    series = Series.load(series_name="plate_001", primary_path=REAL_FIXTURE_SLP)
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+    assert {row["track_id"] for row in result["tracks"]} == {
+        "track_0",
+        "track_1",
+        "track_2",
+        "track_3",
+        "track_4",
+        "track_5",
+    }

--- a/tests/test_tracked_tip_pipeline.py
+++ b/tests/test_tracked_tip_pipeline.py
@@ -279,6 +279,32 @@ def test_compute_tracked_tip_traits_zero_tracks(tmp_path):
     assert result["trajectories"] == []
 
 
+def test_column_constants_are_immutable_tuples():
+    """`_SUMMARY_COLUMNS` and `_TRAJECTORY_COLUMNS` SHALL be tuples, not lists.
+
+    Internal hardening surfaced by /review-pr on PR #190. Pandas does not
+    copy the iterable passed to the `columns=` argument — if a downstream
+    caller (or test) mutates the underlying list, every subsequent pipeline
+    call would silently produce a different column ordering. Tuples
+    eliminate the mutation surface entirely. Matches the existing
+    convention `_VALID_ROOT_TYPES = ("primary", "lateral", "crown")` in
+    sleap_roots/series.py.
+    """
+    from sleap_roots.tracked_tip_pipeline import (
+        _SUMMARY_COLUMNS,
+        _TRAJECTORY_COLUMNS,
+    )
+
+    assert isinstance(_SUMMARY_COLUMNS, tuple), (
+        f"_SUMMARY_COLUMNS must be a tuple for immutability, "
+        f"got {type(_SUMMARY_COLUMNS).__name__}"
+    )
+    assert isinstance(_TRAJECTORY_COLUMNS, tuple), (
+        f"_TRAJECTORY_COLUMNS must be a tuple for immutability, "
+        f"got {type(_TRAJECTORY_COLUMNS).__name__}"
+    )
+
+
 def test_pipeline_traits_list_pickles_cleanly():
     """TraitDef `fn` values SHALL be picklable (no inline lambdas).
 

--- a/tests/test_tracked_tip_pipeline.py
+++ b/tests/test_tracked_tip_pipeline.py
@@ -278,6 +278,61 @@ def test_compute_tracked_tip_traits_zero_tracks(tmp_path):
     assert result["trajectories"] == []
 
 
+def test_tracking_coverage_bounded_when_track_has_duplicate_frame(tmp_path):
+    """Duplicate (track_id, frame) MUST NOT inflate tracking_coverage above 1.0.
+
+    Surfaced by /review-pr on PR #190: pathological tracker output (e.g.
+    over-eager track merging) can produce two instances with the same
+    `inst.track.name` in the same frame. The previous implementation used
+    `n_frames_tracked = len(group)` which counted instances, not unique
+    frames — so a 1-frame .slp with 2 same-track instances yielded
+    `tracking_coverage = 2.0`, violating the spec contract that
+    `tracking_coverage ∈ [0.0, 1.0]`.
+
+    Fix: `n_frames_tracked = int(group["frame"].nunique())`.
+    """
+    Path(tmp_path).mkdir(parents=True, exist_ok=True)
+    image_h, image_w = 200, 200
+    img_array = np.zeros((image_h, image_w), dtype=np.uint8)
+    tif_path = tmp_path / "s.tif"
+    from PIL import Image
+
+    Image.fromarray(img_array).save(tif_path.as_posix(), dpi=(72, 72))
+    video = sio.Video.from_filename(tif_path.as_posix())
+    skeleton = sio.Skeleton(nodes=[sio.Node("r0")])
+    track = sio.Track(name="t")
+    # ONE frame, TWO instances both with the SAME track — pathological.
+    pts_a = np.array([[10.0, 20.0]])
+    pts_b = np.array([[15.0, 25.0]])
+    inst_a = sio.Instance.from_numpy(pts_a, skeleton=skeleton, track=track)
+    inst_b = sio.Instance.from_numpy(pts_b, skeleton=skeleton, track=track)
+    lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[inst_a, inst_b])
+    labels = sio.Labels(
+        labeled_frames=[lf], skeletons=[skeleton], videos=[video], tracks=[track]
+    )
+    slp_path = tmp_path / "s.primary.tracked.slp"
+    sio.save_slp(labels, slp_path.as_posix())
+
+    series = Series.load(series_name="s", primary_path=slp_path.as_posix())
+    result = TrackedTipPipeline().compute_tracked_tip_traits(series)
+
+    assert len(result["tracks"]) == 1
+    row = result["tracks"][0]
+    assert row["track_id"] == "t"
+    assert (
+        row["n_frames_tracked"] == 1
+    ), f"n_frames_tracked must be unique-frame count, got {row['n_frames_tracked']}"
+    assert row["n_frames_total"] == 1
+    assert (
+        row["tracking_coverage"] == 1.0
+    ), f"tracking_coverage must be bounded to [0,1], got {row['tracking_coverage']}"
+
+    # Trajectory rows still record every tracked instance — duplicates
+    # remain visible in the per-frame table for downstream debugging.
+    # Only the per-track summary deduplicates.
+    assert len(result["trajectories"]) == 2
+
+
 def test_compute_tracked_tip_traits_emits_sample_uid_and_timepoint_from_csv(tmp_path):
     """§6.15: with CSV → sample_uid and timepoint resolved from CSV."""
     series = _build_tracked_slp(


### PR DESCRIPTION
## Summary

Implements **Workstream 2** of the [2026-04-23 timelapse design](docs/superpowers/specs/2026-04-23-timelapse-diff-and-tip-kinematics-design.md). Closes **#129**.

`TrackedTipPipeline` is a **root-agnostic, substrate-only** pipeline that consumes SLEAP-tracked `.slp` predictions and emits two coordinated tables:

1. **Trajectory rows** (per-track-per-frame): `series, sample_uid, timepoint, track_id, frame, tip_x, tip_y`.
2. **Track summary** (per-track): `series, sample_uid, timepoint, track_id, n_frames_tracked, n_frames_total, tracking_coverage, tip_trajectory_length, tip_displacement_net`.

Plus a JSON twin with `schema_version=1`, structured `units`, and both tables under `{tracks, trajectories}`. Per-series + batch (`compute_batch_tracked_tip_traits`) variants. `emit_trajectories=True` kwarg lets large batches skip the bulky trajectory CSV.

### Scope is FROZEN

Velocity, curvature, smoothness, tortuosity, direction-changes, circumnutation traits — **none of these belong in `TrackedTipPipeline` now or in the future.** They live in separate downstream pipeline classes (e.g. a future `CircumnutationPipeline`) that REUSE this pipeline's `Series.get_tracked_tips` accessor and trajectory output as their input substrate. Keeping `TrackedTipPipeline` minimal makes it reusable across many downstream pipelines without coupling to any single analysis's opinions.

## What's new

- **`sleap_roots/tracked_tip_pipeline.py`** (NEW FILE, ~420 LOC) — `TrackedTipPipeline(Pipeline)` class. Lives in its own module; starts the per-pipeline-file pattern (megafile split tracked in #189). DAG-A composition: `tip_displacement_net` → `bases.get_base_tip_dist`, `tip_trajectory_length` → `lengths.get_root_lengths`, both used DIRECTLY as TraitDef `fn` values via DAG slicing of `track_first_xy` / `track_last_xy`. **No new trait module** (`tip_kinematics.py` deliberately not created).
- **`sleap_roots/series.py`** (extended) — `Series.get_tracked_tips(root_type=None)` returns frame-sorted long-format DataFrame; `validate_tracked_slp` and `validate_series_for_tracked_tip` module-level helpers.
- **`tests/data/circumnutation_plate/`** — real test fixture (184 KB tracked .slp from circumnutation source data, 311 frames, 6 tracks, single-node skeleton; synthesized plate-level CSV; README per #168 template).
- **`notebooks/TrackedTipPipeline_Mermaid_Graph.md`** — DAG visualization mirroring the existing per-pipeline mermaid graphs.
- **`docs/changelog.md`** — `[Unreleased]` entries.
- **`openspec/changes/add-tracked-tip-pipeline/`** — proposal / design / tasks / spec, all validating `--strict`. 98/109 tasks done; remaining 11 are tutorial-notebook deferral, coverage check, and §16-§17 PR/archive tasks.

## Single-frame edge case asymmetry (deliberate)

`tip_displacement_net = 0.0` (geometric — `xy[0] == xy[-1]` from `get_base_tip_dist`). `tip_trajectory_length = NaN` (codebase NaN-on-empty-segments convention from `get_root_lengths`). Trade-off accepted for full DAG-A purism (no wrapper module). Documented in the spec; users `fillna(0.0)` post-hoc or filter on `n_frames_tracked > 1`.

## Follow-ups already filed

- **#186** — Per-frame metadata accessor on `Series` (companion CSV with timestamps, source filenames). Required before any pipeline emits real-time-per-frame columns. This PR uses integer `frame` only.
- **#187** — Preprocessing helpers: image folder → `.h5` + per-frame metadata CSV.
- **#188** — Generic source-META → sleap-roots-CSV converter. The fixture CSV in this PR is synthesized by hand pending this helper.
- **#189** — Refactor: split `trait_pipelines.py` (3763 lines, 8 pipelines) into per-pipeline modules. This PR's `tracked_tip_pipeline.py` starts the pattern.

## Test plan

- [x] **544 tests passing** total (368 pre-existing + 176 new for this PR). No regressions.
- [x] **34 pipeline tests** in `tests/test_tracked_tip_pipeline.py`: DAG composition (exact-value assertions on straight-line, round-trip, 3-4-5-triangle paths), CSV/JSON emission (column order, file names, NaN→null), batch concat (3 series → 6 summary rows / 30 trajectory rows / list-of-3 JSON), `emit_trajectories=False` skip path, single-frame edge-case asymmetry, zero-track empty-arrays.
- [x] **16 accessor + validator tests** in `tests/test_series.py`: root_type auto-detect, multiple-paths-populated `ValueError`, untracked-instance and empty-track-name error paths, single-node and multi-node skeleton support, frame-sort regression for the brainstorm-verified track-order non-determinism.
- [x] **4 real-fixture integration tests** on the committed `circumnutation_plate` fixture: with-CSV path (asserts `sample_uid="plate_001"`, `timepoint=0.0`, 6 tracks, 1866 trajectory rows, all `tracking_coverage ∈ [0, 1]`); no-CSV path (asserts default `sample_uid` + NaN `timepoint`); exact track-name set; track-order-non-determinism regression test verifying frame 0 vs frame 1 positional order differs but pipeline still groups correctly by `track_id`.
- [x] `uv run black --check` clean.
- [x] `uv run pydocstyle --convention=google` clean for the new files.
- [x] `openspec validate add-tracked-tip-pipeline --strict` clean.

## Verifying locally

```bash
uv sync
uv run pytest tests/test_tracked_tip_pipeline.py tests/test_series.py -v
uv run pytest tests/                                                       # full suite
openspec validate add-tracked-tip-pipeline --strict
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)